### PR TITLE
Unify duplicated S3 listing methods into shared helpers

### DIFF
--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -510,7 +510,10 @@ impl S3Storage {
                             code,
                             msg,
                         );
-                        anyhow::anyhow!(e).context("aws_sdk_s3::client::list_objects_v2() failed.")
+                        anyhow::anyhow!(e).context(format!(
+                            "aws_sdk_s3::client::list_objects_v2() failed. s3://{}/{}",
+                            self.bucket, prefix
+                        ))
                     })?;
 
                 let objects = output
@@ -558,8 +561,10 @@ impl S3Storage {
                             code,
                             msg,
                         );
-                        anyhow::anyhow!(e)
-                            .context("aws_sdk_s3::client::list_object_versions() failed.")
+                        anyhow::anyhow!(e).context(format!(
+                            "aws_sdk_s3::client::list_object_versions() failed. s3://{}/{}",
+                            self.bucket, prefix
+                        ))
                     })?;
 
                 let mut objects: Vec<S3Object> = output
@@ -1721,5 +1726,10 @@ mod tests {
             .list_with_parallel(ListingMode::Objects, "", &sender, 1000, 1, permit)
             .await;
         assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("my-prefix/"),
+            "Error should reference the resolved prefix 'my-prefix/', got: {err_msg}"
+        );
     }
 }

--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -112,6 +112,48 @@ struct S3Storage {
     listing_worker_semaphore: Arc<tokio::sync::Semaphore>,
 }
 
+/// Listing mode for S3 object enumeration.
+///
+/// Used to unify the parallel and sequential listing logic for both
+/// ListObjectsV2 and ListObjectVersions APIs.
+#[derive(Clone, Copy)]
+enum ListingMode {
+    /// List current objects (non-versioned) via ListObjectsV2 API.
+    Objects,
+    /// List all object versions and delete markers via ListObjectVersions API.
+    Versions,
+}
+
+impl ListingMode {
+    /// Returns a label for log messages (e.g. "object" or "object version").
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Objects => "object",
+            Self::Versions => "object version",
+        }
+    }
+}
+
+/// A normalized page of listing results from either S3 listing API.
+///
+/// Abstracts over the differences between ListObjectsV2Output and
+/// ListObjectVersionsOutput so that paging/recursion logic can be shared.
+#[derive(Debug)]
+struct ListPage {
+    /// S3 objects found at this level (converted to S3Object).
+    objects: Vec<S3Object>,
+    /// Sub-prefixes (common prefixes / "directories") discovered via delimiter.
+    sub_prefixes: Vec<String>,
+    /// Whether there are more results to fetch.
+    is_truncated: bool,
+    /// Next continuation token (ListObjectsV2 only).
+    continuation_token: Option<String>,
+    /// Next key marker (ListObjectVersions only).
+    key_marker: Option<String>,
+    /// Next version ID marker (ListObjectVersions only).
+    version_id_marker: Option<String>,
+}
+
 #[async_trait]
 impl StorageTrait for S3Storage {
     fn is_express_onezone_storage(&self) -> bool {
@@ -119,227 +161,13 @@ impl StorageTrait for S3Storage {
     }
 
     async fn list_objects(&self, sender: &Sender<S3Object>, max_keys: i32) -> Result<()> {
-        // Dispatch to parallel listing if configured (adapted from s3sync)
-        if self.config.max_parallel_listings > 1 {
-            if !self.is_express_onezone_storage() {
-                tracing::debug!(
-                    "Using parallel listing with {} workers.",
-                    self.config.max_parallel_listings
-                );
-                let permit = self
-                    .listing_worker_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("listing semaphore closed unexpectedly");
-                return self
-                    .list_objects_with_parallel("", sender, max_keys, 1, permit)
-                    .await
-                    .context("Failed to parallel object listing.");
-            } else if self.config.allow_parallel_listings_in_express_one_zone {
-                tracing::debug!(
-                    "Using parallel listing with {} workers (Express One Zone).",
-                    self.config.max_parallel_listings
-                );
-                let permit = self
-                    .listing_worker_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("listing semaphore closed unexpectedly");
-                return self
-                    .list_objects_with_parallel("", sender, max_keys, 1, permit)
-                    .await
-                    .context("Failed to parallel object listing.");
-            }
-        }
-
-        // Sequential listing fallback
-        tracing::debug!("Disabled parallel listing.");
-        let mut continuation_token: Option<String> = None;
-
-        loop {
-            if self.cancellation_token.is_cancelled() {
-                tracing::info!("Listing cancelled");
-                break;
-            }
-
-            self.exec_rate_limit_objects_per_sec().await;
-
-            let output = self
-                .client
-                .as_ref()
-                .expect("S3 client not initialized")
-                .list_objects_v2()
-                .set_request_payer(self.request_payer.clone())
-                .bucket(&self.bucket)
-                .prefix(&self.prefix)
-                .set_continuation_token(continuation_token.clone())
-                .max_keys(max_keys)
-                .send()
-                .await
-                .map_err(|e| {
-                    let (s3_error_code, s3_error_message) = extract_sdk_error_details(&e);
-                    tracing::error!(
-                        bucket = self.bucket,
-                        prefix = self.prefix,
-                        s3_error_code = s3_error_code,
-                        s3_error_message = s3_error_message,
-                        "S3 ListObjectsV2 API call failed for s3://{}/{}: {} ({}).",
-                        self.bucket,
-                        self.prefix,
-                        s3_error_code,
-                        s3_error_message,
-                    );
-                    anyhow::anyhow!(e).context("aws_sdk_s3::client::list_objects_v2() failed.")
-                })?;
-
-            for object in output.contents() {
-                if self.cancellation_token.is_cancelled() {
-                    return Ok(());
-                }
-
-                let s3_object = S3Object::NotVersioning(aws_sdk_s3::types::Object::clone(object));
-                if let Err(e) = sender
-                    .send(s3_object)
-                    .await
-                    .context("async_channel::Sender::send() failed.")
-                {
-                    return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                }
-            }
-
-            if output.is_truncated() == Some(true) {
-                continuation_token = output.next_continuation_token().map(String::from);
-            } else {
-                break;
-            }
-        }
-
-        Ok(())
+        self.list_dispatch(ListingMode::Objects, sender, max_keys)
+            .await
     }
 
     async fn list_object_versions(&self, sender: &Sender<S3Object>, max_keys: i32) -> Result<()> {
-        // Dispatch to parallel listing if configured
-        if self.config.max_parallel_listings > 1 {
-            if !self.is_express_onezone_storage() {
-                tracing::debug!(
-                    "Using parallel version listing with {} workers.",
-                    self.config.max_parallel_listings
-                );
-                let permit = self
-                    .listing_worker_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("listing semaphore closed unexpectedly");
-                return self
-                    .list_object_versions_with_parallel("", sender, max_keys, 1, permit)
-                    .await
-                    .context("Failed to parallel object version listing.");
-            } else if self.config.allow_parallel_listings_in_express_one_zone {
-                tracing::debug!(
-                    "Using parallel version listing with {} workers (Express One Zone).",
-                    self.config.max_parallel_listings
-                );
-                let permit = self
-                    .listing_worker_semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("listing semaphore closed unexpectedly");
-                return self
-                    .list_object_versions_with_parallel("", sender, max_keys, 1, permit)
-                    .await
-                    .context("Failed to parallel object version listing.");
-            }
-        }
-
-        // Sequential listing fallback
-        tracing::debug!("Disabled parallel version listing.");
-        let mut key_marker: Option<String> = None;
-        let mut version_id_marker: Option<String> = None;
-
-        loop {
-            if self.cancellation_token.is_cancelled() {
-                tracing::info!("Version listing cancelled");
-                break;
-            }
-
-            self.exec_rate_limit_objects_per_sec().await;
-
-            let output = self
-                .client
-                .as_ref()
-                .expect("S3 client not initialized")
-                .list_object_versions()
-                .set_request_payer(self.request_payer.clone())
-                .bucket(&self.bucket)
-                .prefix(&self.prefix)
-                .set_key_marker(key_marker.clone())
-                .set_version_id_marker(version_id_marker.clone())
-                .max_keys(max_keys)
-                .send()
-                .await
-                .map_err(|e| {
-                    let (s3_error_code, s3_error_message) = extract_sdk_error_details(&e);
-                    tracing::error!(
-                        bucket = self.bucket,
-                        prefix = self.prefix,
-                        s3_error_code = s3_error_code,
-                        s3_error_message = s3_error_message,
-                        "S3 ListObjectVersions API call failed for s3://{}/{}: {} ({}).",
-                        self.bucket,
-                        self.prefix,
-                        s3_error_code,
-                        s3_error_message,
-                    );
-                    anyhow::anyhow!(e).context("aws_sdk_s3::client::list_object_versions() failed.")
-                })?;
-
-            // Send object versions
-            for version in output.versions() {
-                if self.cancellation_token.is_cancelled() {
-                    return Ok(());
-                }
-
-                let s3_object =
-                    S3Object::Versioning(aws_sdk_s3::types::ObjectVersion::clone(version));
-                if let Err(e) = sender
-                    .send(s3_object)
-                    .await
-                    .context("async_channel::Sender::send() failed.")
-                {
-                    return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                }
-            }
-
-            // Send delete markers
-            for marker in output.delete_markers() {
-                if self.cancellation_token.is_cancelled() {
-                    return Ok(());
-                }
-
-                let s3_object =
-                    S3Object::DeleteMarker(aws_sdk_s3::types::DeleteMarkerEntry::clone(marker));
-                if let Err(e) = sender
-                    .send(s3_object)
-                    .await
-                    .context("async_channel::Sender::send() failed.")
-                {
-                    return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                }
-            }
-
-            if output.is_truncated() == Some(true) {
-                key_marker = output.next_key_marker().map(String::from);
-                version_id_marker = output.next_version_id_marker().map(String::from);
-            } else {
-                break;
-            }
-        }
-
-        Ok(())
+        self.list_dispatch(ListingMode::Versions, sender, max_keys)
+            .await
     }
 
     async fn head_object(&self, key: &str, version_id: Option<String>) -> Result<HeadObjectOutput> {
@@ -550,9 +378,247 @@ impl S3Storage {
         }
     }
 
+    /// Dispatch listing to parallel or sequential based on configuration.
+    ///
+    /// Adapted from s3sync's parallel/sequential dispatch pattern.
+    async fn list_dispatch(
+        &self,
+        mode: ListingMode,
+        sender: &Sender<S3Object>,
+        max_keys: i32,
+    ) -> Result<()> {
+        if self.config.max_parallel_listings > 1 {
+            let use_parallel = !self.is_express_onezone_storage()
+                || self.config.allow_parallel_listings_in_express_one_zone;
+
+            if use_parallel {
+                let express_suffix = if self.is_express_onezone_storage() {
+                    " (Express One Zone)"
+                } else {
+                    ""
+                };
+                tracing::debug!(
+                    "Using parallel {} listing with {} workers{}.",
+                    mode.label(),
+                    self.config.max_parallel_listings,
+                    express_suffix,
+                );
+                let permit = self
+                    .listing_worker_semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("listing semaphore closed unexpectedly");
+                return self
+                    .list_with_parallel(mode, "", sender, max_keys, 1, permit)
+                    .await
+                    .context(format!("Failed to parallel {} listing.", mode.label()));
+            }
+        }
+
+        // Sequential listing fallback
+        tracing::debug!("Disabled parallel {} listing.", mode.label());
+        self.list_sequential(mode, sender, max_keys).await
+    }
+
+    /// Sequential listing fallback for both objects and object versions.
+    async fn list_sequential(
+        &self,
+        mode: ListingMode,
+        sender: &Sender<S3Object>,
+        max_keys: i32,
+    ) -> Result<()> {
+        let mut continuation_token: Option<String> = None;
+        let mut key_marker: Option<String> = None;
+        let mut version_id_marker: Option<String> = None;
+
+        loop {
+            if self.cancellation_token.is_cancelled() {
+                tracing::info!("{} listing cancelled", mode.label());
+                break;
+            }
+
+            self.exec_rate_limit_objects_per_sec().await;
+
+            let page = self
+                .fetch_list_page(
+                    mode,
+                    &self.prefix,
+                    None,
+                    max_keys,
+                    continuation_token.clone(),
+                    key_marker.clone(),
+                    version_id_marker.clone(),
+                )
+                .await?;
+
+            if self.send_listed_objects(page.objects, sender).await? {
+                return Ok(());
+            }
+
+            if page.is_truncated {
+                continuation_token = page.continuation_token;
+                key_marker = page.key_marker;
+                version_id_marker = page.version_id_marker;
+            } else {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a single page of listing results from the appropriate S3 API.
+    ///
+    /// Normalizes the response into a `ListPage` regardless of which listing
+    /// API was called, so callers don't need to handle the two output types.
+    #[allow(clippy::too_many_arguments)]
+    async fn fetch_list_page(
+        &self,
+        mode: ListingMode,
+        prefix: &str,
+        delimiter: Option<String>,
+        max_keys: i32,
+        continuation_token: Option<String>,
+        key_marker: Option<String>,
+        version_id_marker: Option<String>,
+    ) -> Result<ListPage> {
+        let client = self.client.as_ref().expect("S3 client not initialized");
+
+        match mode {
+            ListingMode::Objects => {
+                let output = client
+                    .list_objects_v2()
+                    .set_request_payer(self.request_payer.clone())
+                    .bucket(&self.bucket)
+                    .prefix(prefix)
+                    .set_delimiter(delimiter)
+                    .set_continuation_token(continuation_token)
+                    .max_keys(max_keys)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        let (code, msg) = extract_sdk_error_details(&e);
+                        tracing::error!(
+                            bucket = self.bucket,
+                            prefix = prefix,
+                            s3_error_code = code,
+                            s3_error_message = msg,
+                            "S3 ListObjectsV2 API call failed for s3://{}/{}: {} ({}).",
+                            self.bucket,
+                            prefix,
+                            code,
+                            msg,
+                        );
+                        anyhow::anyhow!(e).context("aws_sdk_s3::client::list_objects_v2() failed.")
+                    })?;
+
+                let objects = output
+                    .contents()
+                    .iter()
+                    .map(|o| S3Object::NotVersioning(aws_sdk_s3::types::Object::clone(o)))
+                    .collect();
+                let sub_prefixes = output
+                    .common_prefixes()
+                    .iter()
+                    .filter_map(|cp| cp.prefix().map(String::from))
+                    .collect();
+
+                Ok(ListPage {
+                    objects,
+                    sub_prefixes,
+                    is_truncated: output.is_truncated() == Some(true),
+                    continuation_token: output.next_continuation_token().map(String::from),
+                    key_marker: None,
+                    version_id_marker: None,
+                })
+            }
+            ListingMode::Versions => {
+                let output = client
+                    .list_object_versions()
+                    .set_request_payer(self.request_payer.clone())
+                    .bucket(&self.bucket)
+                    .prefix(prefix)
+                    .set_delimiter(delimiter)
+                    .set_key_marker(key_marker)
+                    .set_version_id_marker(version_id_marker)
+                    .max_keys(max_keys)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        let (code, msg) = extract_sdk_error_details(&e);
+                        tracing::error!(
+                            bucket = self.bucket,
+                            prefix = prefix,
+                            s3_error_code = code,
+                            s3_error_message = msg,
+                            "S3 ListObjectVersions API call failed for s3://{}/{}: {} ({}).",
+                            self.bucket,
+                            prefix,
+                            code,
+                            msg,
+                        );
+                        anyhow::anyhow!(e)
+                            .context("aws_sdk_s3::client::list_object_versions() failed.")
+                    })?;
+
+                let mut objects: Vec<S3Object> = output
+                    .versions()
+                    .iter()
+                    .map(|v| S3Object::Versioning(aws_sdk_s3::types::ObjectVersion::clone(v)))
+                    .collect();
+                objects.extend(output.delete_markers().iter().map(|m| {
+                    S3Object::DeleteMarker(aws_sdk_s3::types::DeleteMarkerEntry::clone(m))
+                }));
+                let sub_prefixes = output
+                    .common_prefixes()
+                    .iter()
+                    .filter_map(|cp| cp.prefix().map(String::from))
+                    .collect();
+
+                Ok(ListPage {
+                    objects,
+                    sub_prefixes,
+                    is_truncated: output.is_truncated() == Some(true),
+                    continuation_token: None,
+                    key_marker: output.next_key_marker().map(String::from),
+                    version_id_marker: output.next_version_id_marker().map(String::from),
+                })
+            }
+        }
+    }
+
+    /// Send listed objects to the channel, checking for cancellation.
+    ///
+    /// Returns `Ok(true)` if listing should stop (cancellation or channel closed),
+    /// `Ok(false)` if all objects were sent successfully.
+    async fn send_listed_objects(
+        &self,
+        objects: Vec<S3Object>,
+        sender: &Sender<S3Object>,
+    ) -> Result<bool> {
+        for s3_object in objects {
+            if self.cancellation_token.is_cancelled() {
+                return Ok(true);
+            }
+            if let Err(e) = sender
+                .send(s3_object)
+                .await
+                .context("async_channel::Sender::send() failed.")
+            {
+                return if !sender.is_closed() {
+                    Err(e)
+                } else {
+                    Ok(true)
+                };
+            }
+        }
+        Ok(false)
+    }
+
     /// Recursive parallel listing using S3 delimiter-based prefix partitioning.
     ///
-    /// Adapted from s3sync's `list_objects_with_parallel` algorithm:
+    /// Adapted from s3sync's parallel listing algorithm:
     /// 1. Up to `max_parallel_listing_max_depth`, uses `Delimiter="/"` to discover
     ///    sub-prefixes (common prefixes) alongside objects at the current level.
     /// 2. Objects at the current level are sent directly to the channel.
@@ -562,8 +628,9 @@ impl S3Storage {
     ///    initialized to `config.max_parallel_listings`).
     /// 5. Beyond `max_parallel_listing_max_depth`, no delimiter is set, so listing
     ///    enumerates all objects under the prefix sequentially.
-    fn list_objects_with_parallel<'a>(
+    fn list_with_parallel<'a>(
         &'a self,
+        mode: ListingMode,
         prefix: &'a str,
         sender: &'a Sender<S3Object>,
         max_keys: i32,
@@ -571,8 +638,7 @@ impl S3Storage {
         permit: tokio::sync::OwnedSemaphorePermit,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
         Box::pin(async move {
-            let is_root_prefix = prefix.is_empty();
-            let prefix = if is_root_prefix {
+            let prefix = if prefix.is_empty() {
                 self.prefix.clone()
             } else {
                 prefix.to_string()
@@ -588,159 +654,6 @@ impl S3Storage {
 
             let mut current_permit = Some(permit);
             let mut continuation_token: Option<String> = None;
-
-            loop {
-                if self.cancellation_token.is_cancelled() {
-                    break;
-                }
-
-                self.exec_rate_limit_objects_per_sec().await;
-
-                let output = self
-                    .client
-                    .as_ref()
-                    .expect("S3 client not initialized")
-                    .list_objects_v2()
-                    .set_request_payer(self.request_payer.clone())
-                    .bucket(&self.bucket)
-                    .prefix(&prefix)
-                    .set_delimiter(delimiter.clone())
-                    .set_continuation_token(continuation_token.clone())
-                    .max_keys(max_keys)
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        let (s3_error_code, s3_error_message) = extract_sdk_error_details(&e);
-                        tracing::error!(
-                            bucket = self.bucket,
-                            prefix = prefix,
-                            s3_error_code = s3_error_code,
-                            s3_error_message = s3_error_message,
-                            "S3 ListObjectsV2 API call failed for s3://{}/{}: {} ({}).",
-                            self.bucket,
-                            prefix,
-                            s3_error_code,
-                            s3_error_message,
-                        );
-                        anyhow::anyhow!(e).context("Failed to list objects in parallel listing")
-                    })?;
-
-                // Send objects found at this level
-                for object in output.contents() {
-                    if self.cancellation_token.is_cancelled() {
-                        return Ok(());
-                    }
-
-                    let s3_object =
-                        S3Object::NotVersioning(aws_sdk_s3::types::Object::clone(object));
-                    if let Err(e) = sender
-                        .send(s3_object)
-                        .await
-                        .context("async_channel::Sender::send() failed.")
-                    {
-                        return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                    }
-                }
-
-                // For each common prefix (sub-directory), spawn a parallel task
-                let common_prefixes = output.common_prefixes();
-                if !common_prefixes.is_empty() {
-                    let mut join_set = JoinSet::new();
-
-                    for common_prefix in common_prefixes {
-                        if self.cancellation_token.is_cancelled() {
-                            break;
-                        }
-
-                        if let Some(sub_prefix) = common_prefix.prefix() {
-                            let storage = self.clone();
-                            let sub_prefix = sub_prefix.to_string();
-                            let sender = sender.clone();
-
-                            // Release current permit before acquiring new ones for sub-tasks
-                            if let Some(p) = current_permit.take() {
-                                drop(p);
-                            }
-
-                            // Acquire a new permit (bounded by max_parallel_listings)
-                            let new_permit = self
-                                .listing_worker_semaphore
-                                .clone()
-                                .acquire_owned()
-                                .await
-                                .expect("listing semaphore closed unexpectedly");
-
-                            join_set.spawn(async move {
-                                storage
-                                    .list_objects_with_parallel(
-                                        &sub_prefix,
-                                        &sender,
-                                        max_keys,
-                                        current_depth + 1,
-                                        new_permit,
-                                    )
-                                    .await
-                                    .context("Failed to list objects in sub-prefix")
-                            });
-                        }
-                    }
-
-                    // Wait for all sub-prefix tasks to complete
-                    while let Some(join_result) = join_set.join_next().await {
-                        match join_result {
-                            Err(join_error) => {
-                                self.cancellation_token.cancel();
-                                return Err(anyhow::anyhow!(join_error));
-                            }
-                            Ok(Err(task_error)) => {
-                                self.cancellation_token.cancel();
-                                return Err(task_error);
-                            }
-                            Ok(Ok(())) => {}
-                        }
-                    }
-                }
-
-                if output.is_truncated() != Some(true) {
-                    break;
-                }
-
-                continuation_token = output.next_continuation_token().map(String::from);
-            }
-
-            if let Some(permit) = current_permit {
-                drop(permit);
-            }
-
-            Ok(())
-        })
-    }
-
-    fn list_object_versions_with_parallel<'a>(
-        &'a self,
-        prefix: &'a str,
-        sender: &'a Sender<S3Object>,
-        max_keys: i32,
-        current_depth: usize,
-        permit: tokio::sync::OwnedSemaphorePermit,
-    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
-        Box::pin(async move {
-            let is_root_prefix = prefix.is_empty();
-            let prefix = if is_root_prefix {
-                self.prefix.clone()
-            } else {
-                prefix.to_string()
-            };
-
-            // Use delimiter "/" to discover sub-prefixes up to max depth
-            let delimiter = if current_depth <= self.config.max_parallel_listing_max_depth as usize
-            {
-                Some("/".to_string())
-            } else {
-                None
-            };
-
-            let mut current_permit = Some(permit);
             let mut key_marker: Option<String> = None;
             let mut version_id_marker: Option<String> = None;
 
@@ -751,112 +664,61 @@ impl S3Storage {
 
                 self.exec_rate_limit_objects_per_sec().await;
 
-                let output = self
-                    .client
-                    .as_ref()
-                    .expect("S3 client not initialized")
-                    .list_object_versions()
-                    .set_request_payer(self.request_payer.clone())
-                    .bucket(&self.bucket)
-                    .prefix(&prefix)
-                    .set_delimiter(delimiter.clone())
-                    .set_key_marker(key_marker.clone())
-                    .set_version_id_marker(version_id_marker.clone())
-                    .max_keys(max_keys)
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        let (s3_error_code, s3_error_message) = extract_sdk_error_details(&e);
-                        tracing::error!(
-                            bucket = self.bucket,
-                            prefix = prefix,
-                            s3_error_code = s3_error_code,
-                            s3_error_message = s3_error_message,
-                            "S3 ListObjectVersions API call failed for s3://{}/{}: {} ({}).",
-                            self.bucket,
-                            prefix,
-                            s3_error_code,
-                            s3_error_message,
-                        );
-                        anyhow::anyhow!(e)
-                            .context("Failed to list object versions in parallel listing")
-                    })?;
+                let page = self
+                    .fetch_list_page(
+                        mode,
+                        &prefix,
+                        delimiter.clone(),
+                        max_keys,
+                        continuation_token.clone(),
+                        key_marker.clone(),
+                        version_id_marker.clone(),
+                    )
+                    .await?;
 
-                // Send object versions found at this level
-                for version in output.versions() {
-                    if self.cancellation_token.is_cancelled() {
-                        return Ok(());
-                    }
-
-                    let s3_object =
-                        S3Object::Versioning(aws_sdk_s3::types::ObjectVersion::clone(version));
-                    if let Err(e) = sender
-                        .send(s3_object)
-                        .await
-                        .context("async_channel::Sender::send() failed.")
-                    {
-                        return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                    }
-                }
-
-                // Send delete markers found at this level
-                for marker in output.delete_markers() {
-                    if self.cancellation_token.is_cancelled() {
-                        return Ok(());
-                    }
-
-                    let s3_object =
-                        S3Object::DeleteMarker(aws_sdk_s3::types::DeleteMarkerEntry::clone(marker));
-                    if let Err(e) = sender
-                        .send(s3_object)
-                        .await
-                        .context("async_channel::Sender::send() failed.")
-                    {
-                        return if !sender.is_closed() { Err(e) } else { Ok(()) };
-                    }
+                // Send objects found at this level
+                if self.send_listed_objects(page.objects, sender).await? {
+                    return Ok(());
                 }
 
                 // For each common prefix (sub-directory), spawn a parallel task
-                let common_prefixes = output.common_prefixes();
-                if !common_prefixes.is_empty() {
+                if !page.sub_prefixes.is_empty() {
                     let mut join_set = JoinSet::new();
 
-                    for common_prefix in common_prefixes {
+                    for sub_prefix in page.sub_prefixes {
                         if self.cancellation_token.is_cancelled() {
                             break;
                         }
 
-                        if let Some(sub_prefix) = common_prefix.prefix() {
-                            let storage = self.clone();
-                            let sub_prefix = sub_prefix.to_string();
-                            let sender = sender.clone();
+                        let storage = self.clone();
+                        let sender = sender.clone();
 
-                            // Release current permit before acquiring new ones for sub-tasks
-                            if let Some(p) = current_permit.take() {
-                                drop(p);
-                            }
-
-                            // Acquire a new permit (bounded by max_parallel_listings)
-                            let new_permit = self
-                                .listing_worker_semaphore
-                                .clone()
-                                .acquire_owned()
-                                .await
-                                .expect("listing semaphore closed unexpectedly");
-
-                            join_set.spawn(async move {
-                                storage
-                                    .list_object_versions_with_parallel(
-                                        &sub_prefix,
-                                        &sender,
-                                        max_keys,
-                                        current_depth + 1,
-                                        new_permit,
-                                    )
-                                    .await
-                                    .context("Failed to list object versions in sub-prefix")
-                            });
+                        // Release current permit before acquiring new ones for sub-tasks
+                        if let Some(p) = current_permit.take() {
+                            drop(p);
                         }
+
+                        // Acquire a new permit (bounded by max_parallel_listings)
+                        let new_permit = self
+                            .listing_worker_semaphore
+                            .clone()
+                            .acquire_owned()
+                            .await
+                            .expect("listing semaphore closed unexpectedly");
+
+                        join_set.spawn(async move {
+                            storage
+                                .list_with_parallel(
+                                    mode,
+                                    &sub_prefix,
+                                    &sender,
+                                    max_keys,
+                                    current_depth + 1,
+                                    new_permit,
+                                )
+                                .await
+                                .context(format!("Failed to list {}s in sub-prefix", mode.label()))
+                        });
                     }
 
                     // Wait for all sub-prefix tasks to complete
@@ -875,12 +737,13 @@ impl S3Storage {
                     }
                 }
 
-                if output.is_truncated() != Some(true) {
+                if !page.is_truncated {
                     break;
                 }
 
-                key_marker = output.next_key_marker().map(String::from);
-                version_id_marker = output.next_version_id_marker().map(String::from);
+                continuation_token = page.continuation_token;
+                key_marker = page.key_marker;
+                version_id_marker = page.version_id_marker;
             }
 
             if let Some(permit) = current_permit {
@@ -1331,5 +1194,532 @@ mod tests {
 
         // Must return immediately without touching the rate limiter.
         storage.exec_rate_limit_objects_per_sec_n(0).await;
+    }
+
+    // ---------------------------------------------------------------
+    // ListingMode tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn listing_mode_label_objects() {
+        assert_eq!(ListingMode::Objects.label(), "object");
+    }
+
+    #[test]
+    fn listing_mode_label_versions() {
+        assert_eq!(ListingMode::Versions.label(), "object version");
+    }
+
+    // ---------------------------------------------------------------
+    // Helper: create S3Storage with access to cancellation token
+    // ---------------------------------------------------------------
+
+    fn make_s3_storage_with_token(
+        bucket: &str,
+        prefix: &str,
+    ) -> (S3Storage, crate::types::token::PipelineCancellationToken) {
+        let config = make_test_config(bucket, prefix);
+        let cancellation_token = crate::types::token::create_pipeline_cancellation_token();
+        let ct = cancellation_token.clone();
+        let (stats_sender, _) = async_channel::unbounded();
+        let storage = S3Storage {
+            config,
+            bucket: bucket.to_string(),
+            prefix: prefix.to_string(),
+            cancellation_token,
+            client: None,
+            request_payer: None,
+            stats_sender,
+            rate_limit_objects_per_sec: None,
+            has_warning: Arc::new(AtomicBool::new(false)),
+            listing_worker_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+        };
+        (storage, ct)
+    }
+
+    // ---------------------------------------------------------------
+    // send_listed_objects tests
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn send_listed_objects_empty_vec() {
+        let (storage, _ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, _receiver) = async_channel::unbounded();
+
+        let result = storage.send_listed_objects(vec![], &sender).await.unwrap();
+        assert!(!result, "empty vec should return false (not stopped)");
+    }
+
+    #[tokio::test]
+    async fn send_listed_objects_sends_all_not_versioned() {
+        let (storage, _ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, receiver) = async_channel::unbounded();
+
+        let objects = vec![
+            S3Object::NotVersioning(
+                aws_sdk_s3::types::Object::builder()
+                    .key("file1.txt")
+                    .build(),
+            ),
+            S3Object::NotVersioning(
+                aws_sdk_s3::types::Object::builder()
+                    .key("file2.txt")
+                    .build(),
+            ),
+            S3Object::NotVersioning(
+                aws_sdk_s3::types::Object::builder()
+                    .key("file3.txt")
+                    .build(),
+            ),
+        ];
+
+        let stopped = storage.send_listed_objects(objects, &sender).await.unwrap();
+        assert!(!stopped);
+
+        // All three should be received
+        let r1 = receiver.recv().await.unwrap();
+        assert_eq!(r1.key(), "file1.txt");
+        let r2 = receiver.recv().await.unwrap();
+        assert_eq!(r2.key(), "file2.txt");
+        let r3 = receiver.recv().await.unwrap();
+        assert_eq!(r3.key(), "file3.txt");
+        assert!(receiver.try_recv().is_err(), "no more objects");
+    }
+
+    #[tokio::test]
+    async fn send_listed_objects_sends_versioned_and_delete_markers() {
+        let (storage, _ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, receiver) = async_channel::unbounded();
+
+        let objects = vec![
+            S3Object::Versioning(
+                aws_sdk_s3::types::ObjectVersion::builder()
+                    .key("v1.txt")
+                    .version_id("vid-1")
+                    .build(),
+            ),
+            S3Object::DeleteMarker(
+                aws_sdk_s3::types::DeleteMarkerEntry::builder()
+                    .key("dm1.txt")
+                    .version_id("vid-dm")
+                    .build(),
+            ),
+        ];
+
+        let stopped = storage.send_listed_objects(objects, &sender).await.unwrap();
+        assert!(!stopped);
+
+        let r1 = receiver.recv().await.unwrap();
+        assert!(matches!(r1, S3Object::Versioning(_)));
+        assert_eq!(r1.key(), "v1.txt");
+
+        let r2 = receiver.recv().await.unwrap();
+        assert!(matches!(r2, S3Object::DeleteMarker(_)));
+        assert_eq!(r2.key(), "dm1.txt");
+    }
+
+    #[tokio::test]
+    async fn send_listed_objects_cancelled_before_send() {
+        let (storage, ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        let objects = vec![S3Object::NotVersioning(
+            aws_sdk_s3::types::Object::builder()
+                .key("should-not-send.txt")
+                .build(),
+        )];
+
+        let stopped = storage.send_listed_objects(objects, &sender).await.unwrap();
+        assert!(stopped, "should stop when cancelled");
+        assert!(
+            receiver.try_recv().is_err(),
+            "nothing should have been sent"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_listed_objects_closed_channel_returns_ok_true() {
+        let (storage, _ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, receiver) = async_channel::unbounded::<S3Object>();
+
+        // Close the channel
+        receiver.close();
+
+        let objects = vec![S3Object::NotVersioning(
+            aws_sdk_s3::types::Object::builder()
+                .key("ignored.txt")
+                .build(),
+        )];
+
+        let stopped = storage.send_listed_objects(objects, &sender).await.unwrap();
+        assert!(stopped, "should stop when channel is closed");
+    }
+
+    #[tokio::test]
+    async fn send_listed_objects_bounded_channel_close_mid_send() {
+        let (storage, _ct) = make_s3_storage_with_token("b", "p/");
+        // Bounded channel with capacity 1
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1);
+
+        let objects = vec![
+            S3Object::NotVersioning(
+                aws_sdk_s3::types::Object::builder()
+                    .key("first.txt")
+                    .build(),
+            ),
+            S3Object::NotVersioning(
+                aws_sdk_s3::types::Object::builder()
+                    .key("second.txt")
+                    .build(),
+            ),
+        ];
+
+        // Spawn a task that receives first object then closes channel
+        let recv_handle = tokio::spawn(async move {
+            let obj = receiver.recv().await.unwrap();
+            assert_eq!(obj.key(), "first.txt");
+            receiver.close();
+        });
+
+        let stopped = storage.send_listed_objects(objects, &sender).await.unwrap();
+        assert!(stopped, "should stop when channel is closed mid-send");
+        recv_handle.await.unwrap();
+    }
+
+    // ---------------------------------------------------------------
+    // list_sequential: cancelled immediately
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_sequential_objects_cancelled_immediately() {
+        let (storage, ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, _receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        // Should return Ok(()) without trying to call S3 API (no client needed)
+        let result = storage
+            .list_sequential(ListingMode::Objects, &sender, 1000)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_sequential_versions_cancelled_immediately() {
+        let (storage, ct) = make_s3_storage_with_token("b", "p/");
+        let (sender, _receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        let result = storage
+            .list_sequential(ListingMode::Versions, &sender, 1000)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // list_dispatch: parallel vs sequential routing
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_dispatch_sequential_when_single_worker() {
+        // max_parallel_listings=1 → sequential path → cancel immediately → Ok(())
+        let (storage, ct) = make_s3_storage_with_token("b", "p/");
+        assert_eq!(storage.config.max_parallel_listings, 1);
+        let (sender, _receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        let result = storage
+            .list_dispatch(ListingMode::Objects, &sender, 1000)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn list_dispatch_express_onezone_blocks_parallel_by_default() {
+        // Express One Zone + max_parallel>1 but no allow flag → sequential fallback.
+        // We verify by checking the error message: the parallel path wraps with
+        // "Failed to parallel object listing." while the sequential path does not.
+        let mut config = make_test_config("bucket--az1--x-s3", "prefix/");
+        config.max_parallel_listings = 4;
+        config.max_parallel_listing_max_depth = 1;
+        config.allow_parallel_listings_in_express_one_zone = false;
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let (storage, _, _) =
+            create_test_storage(&config, Some(make_fast_failing_client_config())).await;
+
+        let (sender, _receiver) = async_channel::unbounded();
+        let result = storage.list_objects(&sender, 1000).await;
+
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        // Sequential path error: "list_objects_v2() failed" without parallel wrapper
+        assert!(
+            err_msg.contains("list_objects_v2() failed"),
+            "Expected sequential path error, got: {err_msg}"
+        );
+        assert!(
+            !err_msg.contains("Failed to parallel"),
+            "Should NOT take parallel path for express one zone without allow flag, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dispatch_parallel_objects_api_failure() {
+        // max_parallel>1, non-express, with a real fast-failing client → parallel path
+        let mut config = make_test_config("test-bucket", "prefix/");
+        config.max_parallel_listings = 4;
+        config.max_parallel_listing_max_depth = 1;
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let (storage, _, _) =
+            create_test_storage(&config, Some(make_fast_failing_client_config())).await;
+
+        let (sender, _receiver) = async_channel::unbounded();
+        let result = storage.list_objects(&sender, 1000).await;
+
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        // The parallel path wraps with "Failed to parallel object listing."
+        assert!(
+            err_msg.contains("Failed to parallel object listing"),
+            "Expected parallel path error context, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dispatch_parallel_versions_api_failure() {
+        let mut config = make_test_config("test-bucket", "prefix/");
+        config.max_parallel_listings = 4;
+        config.max_parallel_listing_max_depth = 1;
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let (storage, _, _) =
+            create_test_storage(&config, Some(make_fast_failing_client_config())).await;
+
+        let (sender, _receiver) = async_channel::unbounded();
+        let result = storage.list_object_versions(&sender, 1000).await;
+
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("Failed to parallel object version listing"),
+            "Expected parallel path error context, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_dispatch_express_onezone_allows_parallel_when_configured() {
+        // Express One Zone + allow flag + max_parallel>1 → parallel path (fails on API)
+        let mut config = make_test_config("bucket--az1--x-s3", "prefix/");
+        config.max_parallel_listings = 2;
+        config.max_parallel_listing_max_depth = 1;
+        config.allow_parallel_listings_in_express_one_zone = true;
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let (storage, _, _) =
+            create_test_storage(&config, Some(make_fast_failing_client_config())).await;
+
+        let (sender, _receiver) = async_channel::unbounded();
+        let result = storage.list_objects(&sender, 1000).await;
+
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        // Should take parallel path
+        assert!(
+            err_msg.contains("Failed to parallel object listing"),
+            "Expected parallel path error context, got: {err_msg}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // fetch_list_page: error messages
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_list_page_objects_error_message() {
+        let mut config = make_test_config("test-bucket", "prefix/");
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let cancellation_token = crate::types::token::create_pipeline_cancellation_token();
+        let (stats_sender, _) = async_channel::unbounded();
+
+        let client_config = make_fast_failing_client_config();
+        let client = Some(Arc::new(client_config.create_client().await));
+
+        let storage = S3Storage {
+            config,
+            bucket: "test-bucket".to_string(),
+            prefix: "prefix/".to_string(),
+            cancellation_token,
+            client,
+            request_payer: None,
+            stats_sender,
+            rate_limit_objects_per_sec: None,
+            has_warning: Arc::new(AtomicBool::new(false)),
+            listing_worker_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+        };
+
+        let result = storage
+            .fetch_list_page(
+                ListingMode::Objects,
+                "prefix/",
+                None,
+                1000,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("list_objects_v2() failed"),
+            "Expected list_objects_v2 error, got: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_list_page_versions_error_message() {
+        let mut config = make_test_config("test-bucket", "prefix/");
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let cancellation_token = crate::types::token::create_pipeline_cancellation_token();
+        let (stats_sender, _) = async_channel::unbounded();
+
+        let client_config = make_fast_failing_client_config();
+        let client = Some(Arc::new(client_config.create_client().await));
+
+        let storage = S3Storage {
+            config,
+            bucket: "test-bucket".to_string(),
+            prefix: "prefix/".to_string(),
+            cancellation_token,
+            client,
+            request_payer: None,
+            stats_sender,
+            rate_limit_objects_per_sec: None,
+            has_warning: Arc::new(AtomicBool::new(false)),
+            listing_worker_semaphore: Arc::new(tokio::sync::Semaphore::new(1)),
+        };
+
+        let result = storage
+            .fetch_list_page(
+                ListingMode::Versions,
+                "prefix/",
+                None,
+                1000,
+                None,
+                None,
+                None,
+            )
+            .await;
+        assert!(result.is_err());
+        let err_msg = format!("{:#}", result.unwrap_err());
+        assert!(
+            err_msg.contains("list_object_versions() failed"),
+            "Expected list_object_versions error, got: {err_msg}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // list_with_parallel: cancelled immediately
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_with_parallel_cancelled_immediately() {
+        let (mut storage, ct) = make_s3_storage_with_token("b", "p/");
+        storage.config.max_parallel_listings = 2;
+        storage.listing_worker_semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+        let (sender, _receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        let permit = storage
+            .listing_worker_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .unwrap();
+
+        let result = storage
+            .list_with_parallel(ListingMode::Objects, "", &sender, 1000, 1, permit)
+            .await;
+        assert!(
+            result.is_ok(),
+            "cancelled parallel listing should return Ok"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_with_parallel_versions_cancelled_immediately() {
+        let (mut storage, ct) = make_s3_storage_with_token("b", "p/");
+        storage.config.max_parallel_listings = 2;
+        storage.listing_worker_semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+        let (sender, _receiver) = async_channel::unbounded();
+
+        ct.cancel();
+
+        let permit = storage
+            .listing_worker_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .unwrap();
+
+        let result = storage
+            .list_with_parallel(ListingMode::Versions, "", &sender, 1000, 1, permit)
+            .await;
+        assert!(result.is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // list_with_parallel: empty prefix uses self.prefix
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn list_with_parallel_empty_prefix_uses_storage_prefix() {
+        // With an empty prefix and a fast-failing client, the error message
+        // should reference the storage's own prefix (verifying prefix resolution).
+        let mut config = make_test_config("test-bucket", "my-prefix/");
+        config.max_parallel_listings = 2;
+        config.max_parallel_listing_max_depth = 1;
+        config.target_client_config = Some(make_fast_failing_client_config());
+
+        let cancellation_token = crate::types::token::create_pipeline_cancellation_token();
+        let (stats_sender, _) = async_channel::unbounded();
+        let client_config = make_fast_failing_client_config();
+        let client = Some(Arc::new(client_config.create_client().await));
+
+        let storage = S3Storage {
+            config,
+            bucket: "test-bucket".to_string(),
+            prefix: "my-prefix/".to_string(),
+            cancellation_token,
+            client,
+            request_payer: None,
+            stats_sender,
+            rate_limit_objects_per_sec: None,
+            has_warning: Arc::new(AtomicBool::new(false)),
+            listing_worker_semaphore: Arc::new(tokio::sync::Semaphore::new(2)),
+        };
+
+        let (sender, _receiver) = async_channel::unbounded();
+        let permit = storage
+            .listing_worker_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .unwrap();
+
+        // Empty prefix "" → should resolve to "my-prefix/"
+        let result = storage
+            .list_with_parallel(ListingMode::Objects, "", &sender, 1000, 1, permit)
+            .await;
+        assert!(result.is_err());
     }
 }

--- a/tests/e2e_listing.rs
+++ b/tests/e2e_listing.rs
@@ -736,3 +736,163 @@ async fn e2e_5k_hierarchy_delete_without_prefix() {
     .await
     .expect("e2e_5k_hierarchy_delete_without_prefix timed out");
 }
+
+// ---------------------------------------------------------------------------
+// Express One Zone: 5,000 complex hierarchical objects with parallel listing
+// ---------------------------------------------------------------------------
+
+/// Returns the availability zone ID for Express One Zone directory buckets.
+///
+/// Reads `S3RM_E2E_AZ_ID` from the environment; falls back to `apne1-az4`
+/// (ap-northeast-1 AZ 4) which is a commonly available Express One Zone AZ.
+fn express_az_id() -> String {
+    std::env::var("S3RM_E2E_AZ_ID").unwrap_or_else(|_| "apne1-az4".to_string())
+}
+
+#[tokio::test]
+async fn e2e_5k_hierarchy_express_one_zone_delete_with_prefix() {
+    tokio::time::timeout(LARGE_HIERARCHY_TIMEOUT, async {
+        // Purpose: Verify that 5,000 objects in a deeply nested hierarchy are
+        //          correctly listed and deleted on an Express One Zone directory
+        //          bucket when targeting a sub-prefix with parallel listing.
+        //          Express One Zone buckets require --allow-parallel-listings-in-
+        //          express-one-zone to enable parallel listing; without it the
+        //          pipeline falls back to sequential listing.
+        //
+        // Setup:   Express One Zone directory bucket with 5,000 objects under "hier/".
+        //          Target only "hier/dept-0/" (2,500 objects).
+        //          Use --allow-parallel-listings-in-express-one-zone with 4 workers.
+        //
+        // Expected: Exactly 2,500 objects deleted; 2,500 remain under dept-1/.
+
+        let az_id = express_az_id();
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_directory_bucket_name(&az_id);
+        helper.create_directory_bucket(&bucket, &az_id).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload 5,000 objects
+        let objects = generate_hierarchy_objects("hier");
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        // Verify pre-state
+        let pre_count = helper.count_objects(&bucket, "hier/").await;
+        assert_eq!(pre_count, 5_000, "Should start with 5,000 objects");
+
+        // Delete only dept-0 (2,500 objects)
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/hier/dept-0/"),
+            "--allow-parallel-listings-in-express-one-zone",
+            "--max-parallel-listings",
+            "4",
+            "--max-parallel-listing-max-depth",
+            "4",
+            "--worker-size",
+            "16",
+            "--batch-size",
+            "500",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 2_500,
+            "Should delete exactly 2,500 objects under dept-0/"
+        );
+        assert_eq!(
+            result.stats.stats_failed_objects, 0,
+            "No objects should fail"
+        );
+
+        // Verify dept-0 is empty
+        let dept0_remaining = helper.count_objects(&bucket, "hier/dept-0/").await;
+        assert_eq!(dept0_remaining, 0, "dept-0/ should be completely empty");
+
+        // Verify the other 2,500 objects remain
+        let total_remaining = helper.count_objects(&bucket, "hier/").await;
+        assert_eq!(
+            total_remaining, 2_500,
+            "2,500 objects should remain in dept-1/"
+        );
+
+        guard.cleanup().await;
+    })
+    .await
+    .expect("e2e_5k_hierarchy_express_one_zone_delete_with_prefix timed out");
+}
+
+#[tokio::test]
+async fn e2e_5k_hierarchy_express_one_zone_delete_without_prefix() {
+    tokio::time::timeout(LARGE_HIERARCHY_TIMEOUT, async {
+        // Purpose: Verify that 5,000 objects in a deeply nested hierarchy are
+        //          correctly listed and deleted on an Express One Zone directory
+        //          bucket when targeting the entire bucket (empty prefix).
+        //          Uses --allow-parallel-listings-in-express-one-zone for parallel
+        //          listing from the root.
+        //
+        // Setup:   Express One Zone directory bucket with 5,000 objects.
+        //          Target "s3://bucket/" (empty prefix).
+        //          Use --allow-parallel-listings-in-express-one-zone with 4 workers.
+        //
+        // Expected: All 5,000 objects deleted; bucket is empty.
+
+        let az_id = express_az_id();
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_directory_bucket_name(&az_id);
+        helper.create_directory_bucket(&bucket, &az_id).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload 5,000 objects
+        let objects = generate_hierarchy_objects("root");
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        // Verify pre-state
+        let pre_count = helper.count_objects(&bucket, "").await;
+        assert_eq!(pre_count, 5_000, "Should start with 5,000 objects");
+
+        // Delete everything in the bucket (empty prefix)
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/"),
+            "--allow-parallel-listings-in-express-one-zone",
+            "--max-parallel-listings",
+            "4",
+            "--max-parallel-listing-max-depth",
+            "3",
+            "--worker-size",
+            "16",
+            "--batch-size",
+            "500",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5_000,
+            "Should delete all 5,000 objects"
+        );
+        assert_eq!(
+            result.stats.stats_failed_objects, 0,
+            "No objects should fail"
+        );
+
+        // Verify bucket is empty
+        let remaining = helper.count_objects(&bucket, "").await;
+        assert_eq!(remaining, 0, "Bucket should be completely empty");
+
+        guard.cleanup().await;
+    })
+    .await
+    .expect("e2e_5k_hierarchy_express_one_zone_delete_without_prefix timed out");
+}

--- a/tests/e2e_listing.rs
+++ b/tests/e2e_listing.rs
@@ -1,0 +1,738 @@
+//! E2E tests for unified listing refactoring.
+//!
+//! Tests that the refactored listing logic (unified ListingMode dispatch,
+//! sequential/parallel paths, pagination) works correctly against real S3
+//! for both object listing and version listing modes.
+
+#![cfg(e2e_test)]
+
+mod common;
+
+use common::TestHelper;
+
+// ---------------------------------------------------------------------------
+// Parallel listing with versioned bucket + delete-all-versions
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_parallel_listing_versioned_objects() {
+    e2e_timeout!(async {
+        // Purpose: Verify parallel listing works correctly with versioned buckets
+        //          when using --delete-all-versions. The list_object_versions API
+        //          returns both versions() and delete_markers(); the unified
+        //          list_with_parallel(Versions, ...) must handle both.
+        //
+        // Setup:   Versioned bucket, 60 keys across 3 sub-prefixes (20 each).
+        //          1. Upload v1 (60 versions)
+        //          2. Delete without --delete-all-versions (creates 60 delete markers)
+        //          3. Upload v2 on same keys (60 new versions)
+        //          Per-key history: v1 → delete-marker → v2
+        //          Total entries: 120 versions + 60 delete markers = 180
+        //
+        // Expected: All 180 entries permanently deleted; nothing remains.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let make_objects = |body: u8| -> Vec<(String, Vec<u8>)> {
+            (0..3)
+                .flat_map(|prefix_idx| {
+                    (0..20).map(move |i| {
+                        (
+                            format!("par-ver/sub{prefix_idx}/file{i:02}.dat"),
+                            vec![body; 50],
+                        )
+                    })
+                })
+                .collect()
+        };
+
+        // Step 1: Upload v1
+        helper
+            .put_objects_parallel(&bucket, make_objects(b'1'))
+            .await;
+
+        // Step 2: Delete without --delete-all-versions → creates delete markers
+        // in the middle of the version history
+        let config_markers =
+            TestHelper::build_config(vec![&format!("s3://{bucket}/par-ver/"), "--force"]);
+        let marker_result = TestHelper::run_pipeline(config_markers).await;
+        assert!(!marker_result.has_error);
+        assert_eq!(marker_result.stats.stats_deleted_objects, 60);
+
+        // Step 3: Upload v2 on same keys → new versions on top of delete markers
+        helper
+            .put_objects_parallel(&bucket, make_objects(b'2'))
+            .await;
+
+        // Verify: 120 versions + 60 delete markers = 180 entries
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        let version_count = pre_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]") && k.starts_with("par-ver/"))
+            .count();
+        let marker_count = pre_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]par-ver/"))
+            .count();
+        assert_eq!(version_count, 120, "Should have 120 versions (v1 + v2)");
+        assert_eq!(
+            marker_count, 60,
+            "Should have 60 delete markers in the middle"
+        );
+
+        // Now delete everything with parallel versioned listing
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/par-ver/"),
+            "--delete-all-versions",
+            "--max-parallel-listings",
+            "3",
+            "--max-parallel-listing-max-depth",
+            "2",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        // 120 versions + 60 delete markers = 180 total deletions
+        assert_eq!(
+            result.stats.stats_deleted_objects, 180,
+            "Should delete all 120 versions + 60 delete markers"
+        );
+
+        // Verify nothing remains
+        let versions = helper.list_object_versions(&bucket).await;
+        let par_ver_versions: Vec<_> = versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("par-ver/") || k.starts_with("[delete-marker]par-ver/"))
+            .collect();
+        assert!(
+            par_ver_versions.is_empty(),
+            "No versions or delete markers should remain under par-ver/"
+        );
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Deep nesting with parallel listing
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_parallel_listing_deep_nesting() {
+    e2e_timeout!(async {
+        // Purpose: Verify parallel listing handles deep prefix hierarchies correctly.
+        //          With max_depth=2, sub-prefixes at levels 1-2 should be discovered
+        //          and parallelized; level 3+ should be listed sequentially within
+        //          their parent task.
+        // Setup:   50 objects across a 3-level deep hierarchy.
+        // Expected: All 50 objects deleted.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let objects: Vec<(String, Vec<u8>)> = (0..2)
+            .flat_map(|a| {
+                (0..5).flat_map(move |b| {
+                    (0..5).map(move |c| {
+                        (
+                            format!("deep/l1-{a}/l2-{b}/l3-{c}/file.dat"),
+                            vec![b'd'; 50],
+                        )
+                    })
+                })
+            })
+            .collect();
+        assert_eq!(objects.len(), 50);
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/deep/"),
+            "--max-parallel-listings",
+            "4",
+            "--max-parallel-listing-max-depth",
+            "2",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 50,
+            "Should delete all 50 deeply nested objects"
+        );
+
+        let remaining = helper.count_objects(&bucket, "deep/").await;
+        assert_eq!(remaining, 0, "No objects should remain under deep/");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sequential non-versioned listing with pagination
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_sequential_listing_pagination() {
+    e2e_timeout!(async {
+        // Purpose: Verify sequential non-versioned listing (max_parallel_listings=1)
+        //          handles pagination correctly with small max_keys. This exercises
+        //          the list_sequential(Objects, ...) path with multiple pages.
+        // Setup:   60 objects under a single prefix. max_keys=7 forces 9 pages
+        //          (8 full pages of 7 + 1 partial page of 4).
+        // Expected: All 60 objects deleted across multiple list pages.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let objects: Vec<(String, Vec<u8>)> = (0..60)
+            .map(|i| (format!("seq-page/file{i:02}.dat"), vec![b's'; 50]))
+            .collect();
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/seq-page/"),
+            "--max-parallel-listings",
+            "1",
+            "--max-keys",
+            "7",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 60,
+            "Should delete all 60 objects across multiple pages"
+        );
+        assert_eq!(
+            result.stats.stats_failed_objects, 0,
+            "No objects should fail"
+        );
+
+        let remaining = helper.count_objects(&bucket, "seq-page/").await;
+        assert_eq!(remaining, 0, "No objects should remain under seq-page/");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sequential versioned listing with pagination
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_sequential_versioned_listing_pagination() {
+    e2e_timeout!(async {
+        // Purpose: Verify sequential version listing (max_parallel_listings=1) handles
+        //          pagination correctly with small max_keys. This exercises the
+        //          list_sequential(Versions, ...) path with multiple pages.
+        // Setup:   Versioned bucket with 30 objects (2 versions each = 60 versions).
+        //          max_keys=10 forces pagination.
+        // Expected: All 60 versions permanently deleted.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload v1
+        for i in 0..30 {
+            helper
+                .put_object(&bucket, &format!("seq-ver/file{i:02}.dat"), vec![b'1'; 50])
+                .await;
+        }
+        // Upload v2
+        for i in 0..30 {
+            helper
+                .put_object(&bucket, &format!("seq-ver/file{i:02}.dat"), vec![b'2'; 50])
+                .await;
+        }
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/seq-ver/"),
+            "--delete-all-versions",
+            "--max-parallel-listings",
+            "1",
+            "--max-keys",
+            "10",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 60,
+            "Should delete all 60 versions"
+        );
+
+        let versions = helper.list_object_versions(&bucket).await;
+        let remaining: Vec<_> = versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("seq-ver/") || k.starts_with("[delete-marker]seq-ver/"))
+            .collect();
+        assert!(remaining.is_empty(), "No versions should remain");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Parallel listing with pagination (small max_keys)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_parallel_listing_with_pagination() {
+    e2e_timeout!(async {
+        // Purpose: Verify parallel listing handles pagination correctly when
+        //          max_keys is small. Each parallel task must paginate through
+        //          its sub-prefix independently.
+        // Setup:   80 objects across 4 sub-prefixes (20 each). max_keys=5 forces
+        //          multiple pages per sub-prefix.
+        // Expected: All 80 objects deleted.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let objects: Vec<(String, Vec<u8>)> = (0..4)
+            .flat_map(|p| {
+                (0..20).map(move |i| (format!("par-page/dir{p}/file{i:02}.dat"), vec![b'p'; 50]))
+            })
+            .collect();
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/par-page/"),
+            "--max-parallel-listings",
+            "3",
+            "--max-parallel-listing-max-depth",
+            "1",
+            "--max-keys",
+            "5",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 80,
+            "Should delete all 80 objects"
+        );
+
+        let remaining = helper.count_objects(&bucket, "par-page/").await;
+        assert_eq!(remaining, 0, "No objects should remain under par-page/");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Parallel versioned listing with pagination
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_parallel_versioned_listing_with_pagination() {
+    e2e_timeout!(async {
+        // Purpose: Verify parallel version listing handles pagination correctly.
+        //          Combines: versioned bucket + parallel listing + small max_keys.
+        //          This is the most complex listing path (list_with_parallel(Versions, ...)
+        //          with pagination in each parallel task).
+        // Setup:   Versioned bucket with 40 objects across 2 sub-prefixes,
+        //          2 versions each = 80 version entries. max_keys=7.
+        // Expected: All 80 versions permanently deleted.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload v1
+        let v1: Vec<(String, Vec<u8>)> = (0..2)
+            .flat_map(|p| {
+                (0..20).map(move |i| (format!("pv-page/dir{p}/file{i:02}.dat"), vec![b'1'; 50]))
+            })
+            .collect();
+        helper.put_objects_parallel(&bucket, v1).await;
+
+        // Upload v2
+        let v2: Vec<(String, Vec<u8>)> = (0..2)
+            .flat_map(|p| {
+                (0..20).map(move |i| (format!("pv-page/dir{p}/file{i:02}.dat"), vec![b'2'; 50]))
+            })
+            .collect();
+        helper.put_objects_parallel(&bucket, v2).await;
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/pv-page/"),
+            "--delete-all-versions",
+            "--max-parallel-listings",
+            "2",
+            "--max-parallel-listing-max-depth",
+            "1",
+            "--max-keys",
+            "7",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 80,
+            "Should delete all 80 versions"
+        );
+
+        let versions = helper.list_object_versions(&bucket).await;
+        let remaining: Vec<_> = versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("pv-page/") || k.starts_with("[delete-marker]pv-page/"))
+            .collect();
+        assert!(remaining.is_empty(), "No versions should remain");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Parallel listing with single prefix (no sub-prefix discovery)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_parallel_listing_flat_prefix() {
+    e2e_timeout!(async {
+        // Purpose: Verify parallel listing works when there are no sub-prefixes
+        //          to discover (all objects are directly under one prefix with no
+        //          "/" delimiter matches). The parallel listing should degrade
+        //          gracefully to a single-task listing.
+        // Setup:   50 objects all directly under flat/ (no sub-directories).
+        // Expected: All 50 objects deleted.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let objects: Vec<(String, Vec<u8>)> = (0..50)
+            .map(|i| (format!("flat/file{i:02}.dat"), vec![b'f'; 50]))
+            .collect();
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/flat/"),
+            "--max-parallel-listings",
+            "4",
+            "--max-parallel-listing-max-depth",
+            "2",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 50,
+            "Should delete all 50 objects"
+        );
+
+        let remaining = helper.count_objects(&bucket, "flat/").await;
+        assert_eq!(remaining, 0, "No objects should remain under flat/");
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Sequential listing with delete markers (versioned, no --delete-all-versions)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_sequential_versioned_creates_delete_markers_then_parallel_cleans() {
+    e2e_timeout!(async {
+        // Purpose: Verify the full versioned listing workflow:
+        //          1. Sequential list_objects → delete → creates delete markers
+        //          2. Parallel list_object_versions (--delete-all-versions) → permanently removes all
+        //          This validates both listing modes work correctly on the same bucket.
+        // Setup:   Versioned bucket with 20 objects.
+        // Expected: Step 1 creates delete markers; Step 2 removes all versions + markers.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..20 {
+            helper
+                .put_object(&bucket, &format!("two-pass/file{i:02}.dat"), vec![b't'; 50])
+                .await;
+        }
+
+        // Step 1: Sequential listing (default) → creates delete markers
+        let config1 =
+            TestHelper::build_config(vec![&format!("s3://{bucket}/two-pass/"), "--force"]);
+        let result1 = TestHelper::run_pipeline(config1).await;
+        assert!(!result1.has_error);
+        assert_eq!(result1.stats.stats_deleted_objects, 20);
+
+        // Verify delete markers were created
+        let versions = helper.list_object_versions(&bucket).await;
+        let markers: Vec<_> = versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]two-pass/"))
+            .collect();
+        assert_eq!(markers.len(), 20, "Should have 20 delete markers");
+
+        // Step 2: Parallel versioned listing → permanently remove everything
+        let config2 = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/two-pass/"),
+            "--delete-all-versions",
+            "--max-parallel-listings",
+            "2",
+            "--max-parallel-listing-max-depth",
+            "1",
+            "--force",
+        ]);
+        let result2 = TestHelper::run_pipeline(config2).await;
+        assert!(!result2.has_error);
+        // Should delete 20 original versions + 20 delete markers = 40
+        assert_eq!(result2.stats.stats_deleted_objects, 40);
+
+        let remaining = helper.list_object_versions(&bucket).await;
+        let two_pass_remaining: Vec<_> = remaining
+            .iter()
+            .filter(|(k, _)| {
+                k.starts_with("two-pass/") || k.starts_with("[delete-marker]two-pass/")
+            })
+            .collect();
+        assert!(
+            two_pass_remaining.is_empty(),
+            "No versions or markers should remain"
+        );
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// 5,000 complex hierarchical objects: with prefix and without prefix
+// ---------------------------------------------------------------------------
+
+/// Extended timeout for the 5k-object hierarchy test (3 minutes).
+const LARGE_HIERARCHY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(180);
+
+/// Generate 5,000 objects arranged in a deeply nested, non-uniform hierarchy.
+///
+/// Structure (6 levels max):
+/// ```text
+/// {root}/dept-{0..1}/team-{0..4}/proj-{0..4}/
+///     src/mod-{0..4}/f{0..9}.rs          = 2*5*5 * 5*10 = 2,500
+///     test/t{0..4}.rs                    = 2*5*5 * 5     =   250
+///     doc/d{0..4}.md                     = 2*5*5 * 5     =   250
+///     data/s{0..3}/r{0..9}.json          = 2*5*5 * 4*10  = 2,000
+///                                                  Total = 5,000
+/// ```
+fn generate_hierarchy_objects(root: &str) -> Vec<(String, Vec<u8>)> {
+    let mut objects = Vec::with_capacity(5_000);
+    let body = vec![b'H'; 64]; // minimal body to keep upload fast
+
+    for dept in 0..2 {
+        for team in 0..5 {
+            for proj in 0..5 {
+                let base = format!("{root}/dept-{dept}/team-{team}/proj-{proj}");
+
+                // src/mod-{m}/f{f}.rs — 5 modules × 10 files = 50 per project
+                for m in 0..5 {
+                    for f in 0..10 {
+                        objects.push((format!("{base}/src/mod-{m}/f{f}.rs"), body.clone()));
+                    }
+                }
+
+                // test/t{t}.rs — 5 files per project
+                for t in 0..5 {
+                    objects.push((format!("{base}/test/t{t}.rs"), body.clone()));
+                }
+
+                // doc/d{d}.md — 5 files per project
+                for d in 0..5 {
+                    objects.push((format!("{base}/doc/d{d}.md"), body.clone()));
+                }
+
+                // data/s{s}/r{r}.json — 4 shards × 10 records = 40 per project
+                for s in 0..4 {
+                    for r in 0..10 {
+                        objects.push((format!("{base}/data/s{s}/r{r}.json"), body.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    assert_eq!(
+        objects.len(),
+        5_000,
+        "hierarchy must produce exactly 5,000 objects"
+    );
+    objects
+}
+
+#[tokio::test]
+async fn e2e_5k_hierarchy_delete_with_prefix() {
+    tokio::time::timeout(LARGE_HIERARCHY_TIMEOUT, async {
+        // Purpose: Verify that 5,000 objects in a deeply nested hierarchy (up to 6
+        //          levels) are correctly listed and deleted when targeting a sub-prefix.
+        //          Exercises the unified list_with_parallel(Objects, ...) with many
+        //          sub-prefix discoveries at multiple depths.
+        //
+        // Setup:   Upload 5,000 objects under "hier/". Target only "hier/dept-0/"
+        //          which contains exactly 2,500 objects (1/2 of total).
+        //          Use parallel listing with 8 workers and max-depth 4 to exercise
+        //          recursive prefix discovery across the deep hierarchy.
+        //
+        // Expected: Exactly 2,500 objects deleted; 2,500 remain under dept-1/.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload 5,000 objects
+        let objects = generate_hierarchy_objects("hier");
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        // Verify pre-state
+        let pre_count = helper.count_objects(&bucket, "hier/").await;
+        assert_eq!(pre_count, 5_000, "Should start with 5,000 objects");
+
+        // Delete only dept-0 (2,500 objects = 5 teams * 5 projects * 100 files)
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/hier/dept-0/"),
+            "--max-parallel-listings",
+            "8",
+            "--max-parallel-listing-max-depth",
+            "4",
+            "--worker-size",
+            "16",
+            "--batch-size",
+            "500",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 2_500,
+            "Should delete exactly 2,500 objects under dept-0/"
+        );
+        assert_eq!(
+            result.stats.stats_failed_objects, 0,
+            "No objects should fail"
+        );
+
+        // Verify dept-0 is empty
+        let dept0_remaining = helper.count_objects(&bucket, "hier/dept-0/").await;
+        assert_eq!(dept0_remaining, 0, "dept-0/ should be completely empty");
+
+        // Verify the other 2,500 objects remain
+        let total_remaining = helper.count_objects(&bucket, "hier/").await;
+        assert_eq!(
+            total_remaining, 2_500,
+            "2,500 objects should remain in dept-1/"
+        );
+
+        guard.cleanup().await;
+    })
+    .await
+    .expect("e2e_5k_hierarchy_delete_with_prefix timed out");
+}
+
+#[tokio::test]
+async fn e2e_5k_hierarchy_delete_without_prefix() {
+    tokio::time::timeout(LARGE_HIERARCHY_TIMEOUT, async {
+        // Purpose: Verify that 5,000 objects in a deeply nested hierarchy are
+        //          correctly listed and deleted when targeting the entire bucket
+        //          (empty prefix). This exercises the root-level parallel listing
+        //          entry point where prefix="" resolves to self.prefix (bucket root).
+        //
+        // Setup:   Upload 5,000 objects directly under the bucket root (no common
+        //          prefix wrapper). Target "s3://bucket/" so the listing starts from
+        //          the root and must discover all top-level dept-* prefixes.
+        //          Use parallel listing with 8 workers and max-depth 3.
+        //
+        // Expected: All 5,000 objects deleted; bucket is empty.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload 5,000 objects at bucket root (no wrapping prefix)
+        let objects = generate_hierarchy_objects("root");
+        helper.put_objects_parallel(&bucket, objects).await;
+
+        // Verify pre-state
+        let pre_count = helper.count_objects(&bucket, "").await;
+        assert_eq!(pre_count, 5_000, "Should start with 5,000 objects");
+
+        // Delete everything in the bucket (empty prefix)
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/"),
+            "--max-parallel-listings",
+            "8",
+            "--max-parallel-listing-max-depth",
+            "3",
+            "--worker-size",
+            "16",
+            "--batch-size",
+            "500",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors: {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5_000,
+            "Should delete all 5,000 objects"
+        );
+        assert_eq!(
+            result.stats.stats_failed_objects, 0,
+            "No objects should fail"
+        );
+
+        // Verify bucket is empty
+        let remaining = helper.count_objects(&bucket, "").await;
+        assert_eq!(remaining, 0, "Bucket should be completely empty");
+
+        guard.cleanup().await;
+    })
+    .await
+    .expect("e2e_5k_hierarchy_delete_without_prefix timed out");
+}


### PR DESCRIPTION
## Summary

- Refactored four duplicated listing methods (`list_objects`, `list_object_versions`, `list_objects_with_parallel`, `list_object_versions_with_parallel`) into shared helpers parameterized by a `ListingMode` enum, reducing ~550 lines of 80%+ structural duplication by ~138 net lines
- Introduced `ListingMode` enum, `ListPage` struct, and five unified methods: `list_dispatch`, `list_sequential`, `fetch_list_page`, `send_listed_objects`, `list_with_parallel`
- Added 20 unit tests covering all new methods (routing, cancellation, channel closure, error messages, Express One Zone handling)
- Added 10 E2E tests (`tests/e2e_listing.rs`) covering parallel/sequential × versioned/non-versioned × pagination, deep nesting, interleaved delete markers, and 5k-object complex hierarchy deletion with and without prefix

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets --all-features` passes with zero warnings
- [x] `cargo test` passes (873 unit + 33 integration + 15 doc tests)
- [x] `RUSTFLAGS="--cfg e2e_test" cargo llvm-cov --all-features` passes — all E2E tests pass, **98.43% line coverage** overall, `storage/s3/mod.rs` at **98.69% line / 100% function coverage**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified object/version listing into a single, consistent listing flow supporting sequential and parallel modes.

* **Bug Fixes**
  * Improved pagination, cancellation and error-context handling across listing paths; more reliable deletions across configurations (including Express One Zone).

* **Tests**
  * Added extensive end-to-end tests validating listing, pagination, and deletion for versioned/non-versioned buckets, large hierarchies, and parallel/sequential settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->