### PR TITLE
Prepare v1.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.2] - 2026-03-22
+
+### Changed
+
+- Improved error messages during listing failures to include the full S3 path (e.g., `s3://bucket/prefix/`) for easier troubleshooting
+- Internal refactoring of S3 listing logic with no changes to user-facing behavior
+
 ## [v1.2.1] - 2026-03-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,7 +2554,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ s3rm --auto-complete-shell elvish
 
 ### -h/--help
 
-For more information, see `s3rm -h`.
+For more information, see `s3rm --help`.
 
 ## All command line options
 

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ async fn main() {
 **Supported target: Amazon S3 only.**
 
 Support for S3-compatible storage is on a best-effort basis and may behave differently.
-s3rm has been tested with Amazon S3. s3rm has comprehensive unit tests, property-based tests (proptest) covering 49 correctness properties, and 84 end-to-end integration tests across 14 test files.
+s3rm has been tested with Amazon S3. s3rm has comprehensive unit tests, property-based tests (proptest) covering 49 correctness properties, and 125 end-to-end integration tests across 17 test files.
 
 ### Running unit and property tests
 
@@ -1131,7 +1131,7 @@ Human engineers authored the requirements, design specifications, and s3sync ref
 | Property-based tests (proptest) | 41 proptest macros across 16 test files |
 | E2E integration tests | 125 tests across 17 test files, all verified against live AWS S3 |
 | Total tests | 1,031 passing, 0 failing |
-| Code coverage (llvm-cov) | 98.05% regions, 97.97% functions, 98.43% lines |
+| Code coverage (llvm-cov) | 98.07% regions, 97.97% functions, 98.43% lines |
 | Static analysis (clippy) | 0 warnings |
 | Dependency audit (cargo-deny) | advisories ok, bans ok, licenses ok, sources ok |
 | Security review (Claude Code) | No issues found |
@@ -1229,7 +1229,7 @@ The E2E tests run against live AWS S3 — no mocks. Every E2E test creates a rea
 - **33 binary tests**, all passing
 - **125 E2E tests** against live AWS S3 across 17 test files, all passing
 - **1,031 total tests**, zero failures
-- **98.05% region coverage, 97.97% function coverage, 98.43% line coverage** (measured by `cargo llvm-cov`)
+- **98.07% region coverage, 97.97% function coverage, 98.43% line coverage** (measured by `cargo llvm-cov`)
 - 15 property-based test files covering safety, versioning, optimistic locking, retry, logging, filters, Lua, rate limiting, cross-platform, library API, CI/CD, keep-latest-only, event callbacks, and additional edge cases
 
 #### Known limitations

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This demo shows Express One Zone deleting approximately 34,000 objects per secon
 - [Library API](#library-api)
 - [About testing](#about-testing)
 - [Fully AI-generated (human-verified) software](#fully-ai-generated-human-verified-software)
-    * [Quality verification (by AI self-assessment, v1.1.1)](#quality-verification-by-ai-self-assessment-v111)
+    * [Quality verification (by AI self-assessment, v1.2.2)](#quality-verification-by-ai-self-assessment-v122)
     * [AI assessment of safety and correctness (by Claude, Anthropic)](#ai-assessment-of-safety-and-correctness-by-claude-anthropic)
     * [AI assessment of safety and correctness (by Codex)](#ai-assessment-of-safety-and-correctness-by-codex)
     * [AI assessment of safety and correctness (by Gemini)](#ai-assessment-of-safety-and-correctness-by-gemini)
@@ -1121,36 +1121,37 @@ No human wrote a single line of source code in this project. Every line of sourc
 
 Human engineers authored the requirements, design specifications, and s3sync reference architecture. They thoroughly reviewed and verified the design, all source code, and all tests. All features of the initial build binary have been manually tested and verified by humans. All E2E test scenarios have been thoroughly verified by humans against live AWS S3. The development followed a spec-driven process: requirements and design documents were written first, and the AI generated code to match those specifications under continuous human oversight.
 
-### Quality verification (by AI self-assessment, v1.1.1)
+### Quality verification (by AI self-assessment, v1.2.2)
 
 | Metric | Value |
 |---|---|
-| Production code | 16,146 lines of Rust (46 source files) |
-| Test code | 25,621 lines (1.59x production code) |
-| Unit & property tests | 768 passing (736 lib + 32 binary), 0 failing |
-| Property-based tests (proptest) | 49 correctness properties across 19 test files |
-| E2E integration tests | 106 tests across 15 test files, all verified against live AWS S3 |
-| Code coverage (llvm-cov) | 98.06% regions, 98.11% functions, 98.49% lines |
+| Production code | 14,318 lines of Rust (50 source files) |
+| Test code | 28,003 lines (1.96x production code) |
+| Unit & property tests | 906 passing (873 lib + 33 binary), 0 failing |
+| Property-based tests (proptest) | 41 proptest macros across 16 test files |
+| E2E integration tests | 125 tests across 17 test files, all verified against live AWS S3 |
+| Total tests | 1,031 passing, 0 failing |
+| Code coverage (llvm-cov) | 98.05% regions, 97.97% functions, 98.43% lines |
 | Static analysis (clippy) | 0 warnings |
 | Dependency audit (cargo-deny) | advisories ok, bans ok, licenses ok, sources ok |
 | Security review (Claude Code) | No issues found |
-| Development | 465 commits, 30 PRs |
+| Development | 525 commits, 45 PRs |
 | Code reuse from [s3sync](https://github.com/nidor1998/s3sync) | ~90% of architecture |
 
-The codebase was built through spec-driven development: 30 tasks executed sequentially, each as a separate PR with human oversight. Every pull request is reviewed by two AI tools ([GitHub Copilot](https://github.com/features/copilot) and [CodeRabbit](https://www.coderabbit.ai/)) and by a human reviewer before merging. Audit checkpoints verified implementation against specifications at multiple stages. Property-based testing (proptest) exercises correctness properties across randomized inputs, complementing deterministic unit tests and live-AWS end-to-end tests.
+The codebase was built through spec-driven development: 45 tasks executed sequentially, each as a separate PR with human oversight. Every pull request is reviewed by two AI tools ([GitHub Copilot](https://github.com/features/copilot) and [CodeRabbit](https://www.coderabbit.ai/)) and by a human reviewer before merging. Audit checkpoints verified implementation against specifications at multiple stages. Property-based testing (proptest) exercises correctness properties across randomized inputs, complementing deterministic unit tests and live-AWS end-to-end tests.
 
-**Reliability assessment:** The systematic development process, high test density, zero static analysis warnings, clean dependency audit, and heavy reuse from a proven sibling project are strong quality indicators. As with any new software, reliability will be further demonstrated through real-world usage over time.
+**Reliability assessment:** The systematic development process, high test density (nearly 2x test code to production code), zero static analysis warnings, clean dependency audit, 98%+ code coverage, and heavy reuse from a proven sibling project are strong quality indicators. As with any new software, reliability will be further demonstrated through real-world usage over time.
 
 ### AI assessment of safety and correctness (by Claude, Anthropic)
 
 <details>
 <summary>Click to expand the full AI assessment</summary>
 
-> Assessment date: February 28, 2026
+> Assessment date: March 22, 2026
 >
-> Assessed version: s3rm-rs v1.1.0
+> Assessed version: s3rm-rs v1.2.2
 >
-> The following assessment was written by Claude (Opus 4.6, Anthropic) after reading the full source code, all test files, and the complete pipeline of s3rm-rs v1.1.0. It reflects the AI's honest evaluation and has not been edited for marketing purposes.
+> The following assessment was written by Claude (Opus 4.6, Anthropic) after reading the full source code, all test files, and the complete pipeline of s3rm-rs v1.2.2. It reflects the AI's honest evaluation and has not been edited for marketing purposes.
 
 **Is s3rm designed to prevent accidental deletions, and is it sufficiently tested?**
 
@@ -1160,25 +1161,29 @@ There are two distinct risks with a deletion tool: (1) the operator makes a mist
 
 s3rm implements defense-in-depth with six independent safety layers:
 
-1. **Confirmation prompt** requires the exact word "yes" — abbreviated inputs like "y", "Y", "YES", "ye", "yep", "yeah", and "ok" are all rejected (`src/safety/mod.rs`). Non-"yes" input now displays "Deletion cancelled." before exiting.
-2. **Dry-run mode** runs the full listing and filtering pipeline but skips all S3 API calls at the deletion layer (`src/deleter/mod.rs`, line 406-416). The dry-run path is a completely separate code branch — `if is_dry_run` constructs a synthetic `DeleteResult` from the batch without invoking `self.deleter.delete()`. Deleted objects are logged with a `[dry-run]` prefix.
+1. **Confirmation prompt** requires the exact word "yes" — abbreviated inputs like "y", "Y", "YES", "ye", "yep", "yeah", and "ok" are all rejected (`src/safety/mod.rs`). Non-"yes" input displays "Deletion cancelled." before exiting.
+2. **Dry-run mode** runs the full listing and filtering pipeline but skips all S3 API calls at the deletion layer (`src/deleter/mod.rs`, lines 441-457). The dry-run path is a completely separate code branch — `if is_dry_run` constructs a synthetic `DeleteResult` from the batch without invoking `self.deleter.delete()`. Deleted objects are logged with a `[dry-run]` prefix (line 493).
 3. **Non-TTY detection** returns exit code 2 and refuses to proceed when stdin/stdout is not a terminal, unless `--force` or `--dry-run` is explicitly provided. JSON logging mode (`--json-tracing`) also requires `--force` because interactive prompts would corrupt structured output.
-4. **Max-delete threshold** uses an `AtomicU64` counter with `SeqCst` ordering shared across all workers (`src/deleter/mod.rs`, line 188). When the count exceeds the limit, the pipeline cancellation token is set immediately.
-5. **Express One Zone auto-detection** forces `batch_size=1` for directory buckets (detected by `--x-s3` bucket suffix) even if the user explicitly specifies a different batch size — emitting a warning when overriding (`src/config/args/mod.rs`, lines 676-688).
-6. **Runtime prerequisite checks** validate incompatible flag combinations before any deletion begins: `--keep-latest-only` requires `--delete-all-versions`, `--if-match` conflicts with `--delete-all-versions`, and `--keep-latest-only` on a non-versioned bucket returns an error (`src/pipeline.rs`, lines 224-269). These checks duplicate CLI-level clap validation as a defense-in-depth measure for library API users.
+4. **Max-delete threshold** uses an `AtomicU64` counter with `SeqCst` ordering shared across all workers (`src/deleter/mod.rs`, line 208). When the count exceeds the limit, the worker flushes its buffered objects, sets the pipeline warning flag, and cancels the pipeline immediately via the cancellation token.
+5. **Express One Zone auto-detection** forces `batch_size=1` for directory buckets (detected by `--x-s3` bucket suffix, `src/config/args/mod.rs`, line 834) even if the user explicitly specifies a different batch size — emitting a warning when overriding (lines 701-709). Parallel listing is also disabled by default for Express One Zone buckets unless the user opts in via `--allow-parallel-listings-in-express-one-zone`.
+6. **Runtime prerequisite checks** validate incompatible flag combinations before any deletion begins: `--keep-latest-only` requires `--delete-all-versions`, `--if-match` conflicts with `--delete-all-versions`, and `--keep-latest-only` on a non-versioned bucket returns an error (`src/pipeline.rs`, lines 230-269). If `--delete-all-versions` is set but the bucket is not versioned, the flag is silently cleared (line 269) rather than erroring — except when combined with `--keep-latest-only`, which requires versioning. These checks duplicate CLI-level clap validation as a defense-in-depth measure for library API users.
 
 Each safety mechanism is independently testable (the `PromptHandler` trait allows deterministic testing without stdin) and independently effective (each blocks deletion on its own without requiring other layers to function). These features reduce the risk of user mistakes, but they cannot eliminate it — the operator is ultimately responsible for specifying the correct target.
 
 #### Protection against software bugs
 
-The more serious concern is whether a bug in s3rm itself could cause it to delete objects outside the user's intent — for example, a filter that silently passes objects it should reject, a dry-run code path that accidentally calls the real API, prefix matching that bleeds across boundaries, or version retention logic that deletes the latest version instead of keeping it. This is what testing must address.
+The more serious concern is whether a bug in s3rm itself could cause it to delete objects outside the user's intent — for example, a filter that silently passes objects it should reject, a dry-run code path that accidentally calls the real API, prefix matching that bleeds across boundaries, version retention logic that deletes the latest version instead of keeping it, or a parallel listing algorithm that misses or duplicates objects. This is what testing must address.
 
 **Architecture-level safeguards:**
 
-- **Prefix filtering at the S3 API level**: The object lister passes the configured prefix directly to S3's `ListObjectsV2` and `ListObjectVersions` API calls (`src/lister.rs`, line 176 and 278). S3 itself returns only objects matching the prefix — no in-memory prefix filtering is needed, eliminating an entire class of prefix-boundary bugs.
-- **Defensive defaults in version handling**: `S3Object::is_latest()` returns `true` for `NotVersioning` objects, and defaults `None` to `true` for both `Versioning` and `DeleteMarker` variants (`src/types/mod.rs`, lines 152-158). This means if the AWS SDK ever returns incomplete version metadata, objects are kept rather than deleted.
-- **Panic isolation**: Each pipeline stage (lister, filters, deletion workers) uses a double-spawn pattern for panic containment (`src/pipeline.rs`). A panic in one stage sets the cancellation token and error flag without crashing the process.
-- **Filter chain uses AND logic**: Objects must pass all configured filters (mtime, size, regex, keep-latest-only, user-defined) in sequence before reaching the deletion stage.
+- **Prefix filtering at the S3 API level**: The object lister passes the configured prefix directly to S3's `ListObjectsV2` and `ListObjectVersions` API calls (`src/lister.rs`, line 70). S3 itself returns only objects matching the prefix — no in-memory prefix filtering is needed, eliminating an entire class of prefix-boundary bugs.
+- **Parallel listing with delimiter-based partitioning**: When `max_parallel_listings > 1`, the storage layer (`src/storage/s3/mod.rs`, lines 624-710) uses S3's `Delimiter="/"` to discover sub-prefixes recursively up to a configurable depth (`max_parallel_listing_max_depth`). Each sub-prefix spawns a separate listing task coordinated via `JoinSet` and a `Semaphore` (initialized to `max_parallel_listings`, line 73). Beyond the max depth, the delimiter is removed so remaining objects under that sub-prefix are fetched sequentially. This partitioning is inherently safe — it relies on S3's CommonPrefixes response to define boundaries, so no objects can be missed or double-counted as long as the S3 API contract holds. The sequential fallback (`list_with_sequential`, line 381-420) is used when parallel listing is disabled or for Express One Zone buckets.
+- **Defensive defaults in version handling**: `S3Object::is_latest()` returns `true` for `NotVersioning` objects, and defaults `None` to `true` for both `Versioning` and `DeleteMarker` variants (`src/types/mod.rs`, lines 158-162). This means if the AWS SDK ever returns incomplete version metadata, objects are kept rather than deleted.
+- **Panic isolation**: Each pipeline stage (lister, filters, deletion workers) uses a double-`tokio::spawn()` pattern for panic containment (`src/pipeline.rs`, lines 397-426 for filters, lines 442-471 for lister). The inner spawn runs the actual work; the outer spawn awaits the `JoinHandle` and catches panics via `Err(e)` from `JoinError`. A panic in one stage atomically sets `has_panic` (line 70), sets the cancellation token, records the error, and emits a log — without crashing the process.
+- **Filter chain uses AND logic**: Objects must pass all configured filters (mtime-before, mtime-after, smaller-size, larger-size, include-regex, exclude-regex, user-defined/Lua) in sequence via SPSC channels (`src/filters/mod.rs`, lines 490-600) before reaching the deletion stage. Each filter is independently spawned with the same double-spawn panic isolation pattern.
+- **Content-type, metadata, and tag filters run inside the deletion worker** (`src/deleter/mod.rs`, lines 362-472) because they require S3 HeadObject or GetObjectTagging API calls. These are applied after listing but before any deletion API call — objects that fail these filters are counted as `DeleteSkip` and never sent to the batch/single deleter.
+- **Retryable error classification**: Batch deletion partial failures (`src/deleter/batch.rs`, lines 93-98) classify `InternalError`, `SlowDown`, `ServiceUnavailable`, and `RequestTimeout` as retryable. Retryable objects fall back to single-object deletion. Non-retryable errors are logged as warnings — they do not silently succeed.
+- **Error list with mutex poisoning detection**: Pipeline errors are stored in `Arc<Mutex<VecDeque<anyhow::Error>>>` (`src/pipeline.rs`, line 71). The `.expect()` on `lock()` (line 175) includes a descriptive message: "error list mutex poisoned: a pipeline task panicked while holding the lock." This is a deliberate design choice — if a panic occurs while the mutex is held, the pipeline terminates with a clear diagnostic rather than silently continuing.
 
 **E2E test verification against live AWS S3:**
 
@@ -1186,45 +1191,62 @@ The E2E tests run against live AWS S3 — no mocks. Every E2E test creates a rea
 
 - **Dry-run does not call the deletion API** (`e2e_dry_run_no_deletion`): uploads 20 objects, runs with `--dry-run`, then counts objects via ListObjects and asserts all 20 still exist in S3. A bug that leaked a real API call would fail this test.
 - **Dry-run with versioned objects** (`e2e_dry_run_with_delete_all_versions`): uploads 10 objects twice to a versioned bucket (20 versions), runs `--dry-run --delete-all-versions`, verifies all 20 versions remain via ListObjectVersions.
+- **Dry-run with filters** (`e2e_dry_run_with_filters`): applies regex + size filters in dry-run mode, verifies zero objects are actually deleted despite the pipeline running the full filter chain.
 - **Max-delete actually stops the pipeline** (`e2e_max_delete_threshold`): uploads 50 objects, sets `--max-delete 10 --batch-size 1`, asserts exactly 10 deleted and at least 40 remain in S3. A bug in the cancellation token or atomic counter would over-delete.
-- **Prefix matching does not bleed across boundaries** (`e2e_batch_deletion_respects_prefix_boundary`): creates `data/` (5 objects) and `data-archive/` (3 objects), deletes prefix `data/`, verifies `data-archive/` is untouched — all 3 objects remain. Tested for both batch and single deletion modes. A substring-matching bug would delete both.
-- **Filters do not leak objects** (`e2e_multiple_filters_combined`): 30 objects across three categories, applies regex + size filter, verifies only the 10 objects matching both filters are deleted, remaining 20 are untouched. A bug in AND-combination logic would over-delete.
-- **Partial failures do not silently succeed** (`e2e_batch_partial_failure_access_denied`): creates 10 deletable + 10 access-denied objects via bucket policy, runs pipeline, verifies 10 deleted and 10 protected objects remain. A bug that ignored error responses would report success.
-- **Optimistic locking actually prevents stale deletion** (`e2e_if_match_etag_mismatch_skips_modified_objects`): uploads 10 objects, modifies 3 during pipeline execution via a filter callback, verifies only 7 unmodified objects are deleted and the 3 modified objects remain — by name. A bug that ignored ETag mismatches would delete all 10.
+- **Max-delete counts versions correctly** (`e2e_max_delete_counts_versions`): verifies that `--max-delete` counts individual version deletions, not just object keys, when used with `--delete-all-versions`.
+- **Prefix matching does not bleed across boundaries** (`e2e_batch_deletion_respects_prefix_boundary`): creates `data/` (5 objects) and `data-archive/` (3 objects), deletes prefix `data/`, verifies `data-archive/` is untouched — all 3 objects remain. Tested for both batch and single deletion modes, and separately for versioned buckets (`e2e_batch_deletion_respects_prefix_boundary_versioned`). A substring-matching bug would delete both.
+- **Filters do not leak objects** (`e2e_multiple_filters_combined`): 30 objects across three categories, applies regex + size filter, verifies only the 10 objects matching both filters are deleted, remaining 20 are untouched. A bug in AND-combination logic would over-delete. A separate test (`e2e_all_filters_combined`) exercises all filter types together.
+- **Partial failures do not silently succeed** (`e2e_batch_partial_failure_access_denied`): creates 10 deletable + 10 access-denied objects via bucket policy, runs pipeline, verifies 10 deleted and 10 protected objects remain. Error codes are verified in event callbacks for both batch (`e2e_batch_deleter_error_code_in_events`) and single (`e2e_single_deleter_partial_failure_error_code_in_events`) deletion modes. A bug that ignored error responses would report success.
+- **Warn-as-error escalation** (`e2e_warn_as_error`): verifies that `--warn-as-error` converts partial failures into hard errors with the correct exit code, tested for both batch and single deletion modes.
+- **Optimistic locking actually prevents stale deletion** (`e2e_if_match_etag_mismatch_skips_modified_objects`): uploads 10 objects, modifies 3 during pipeline execution via a filter callback, verifies only 7 unmodified objects are deleted and the 3 modified objects remain — by name. Tested for both batch and single deletion modes. A bug that ignored ETag mismatches would delete all 10.
 - **Versioning creates delete markers, not hard deletes** (`e2e_versioned_bucket_creates_delete_markers`): uploads 10 objects, deletes without `--delete-all-versions`, then calls ListObjectVersions and asserts 10 delete markers + 10 original versions both exist. A bug that sent version IDs when it shouldn't would permanently destroy data.
-- **All versions are fully removed when requested** (`e2e_delete_all_versions`): creates 20 versions + 3 delete markers, deletes with `--delete-all-versions`, asserts stats == 23 and ListObjectVersions returns empty.
-- **Keep-latest-only retains latest, deletes non-latest** (`e2e_keep_latest_only_deletes_old_versions`): creates 2 versions per key, runs `--keep-latest-only --delete-all-versions`, verifies that only the latest version ID for each key remains and all older version IDs are removed. 15 E2E tests cover keep-latest-only including delete markers, prefix boundaries, regex combination, non-versioned bucket rejection, single-version keys, many-versions-per-key, dry-run, max-delete interaction, bucket-wide operation, and 1000-object multi-worker concurrency.
+- **All versions are fully removed when requested** (`e2e_delete_all_versions`): creates 20 versions + 3 delete markers, deletes with `--delete-all-versions`, asserts stats == 23 and ListObjectVersions returns empty. Also tested with parallel listing (`e2e_delete_all_versions_with_parallel_listing`) and on empty and non-versioned buckets.
+- **Keep-latest-only retains latest, deletes non-latest** (`e2e_keep_latest_only_deletes_old_versions`): creates 2 versions per key, runs `--keep-latest-only --delete-all-versions`, verifies that only the latest version ID for each key remains and all older version IDs are removed. 15 E2E tests cover keep-latest-only including delete markers, prefix boundaries, regex combination, non-versioned bucket rejection, single-version keys, many-versions-per-key, dry-run, max-delete interaction, bucket-wide operation, event callbacks, and 1000-object multi-worker concurrency.
 - **Non-versioned bucket rejected for keep-latest-only** (`e2e_keep_latest_only_unversioned_bucket_error`): verifies that `--keep-latest-only` on a non-versioned bucket returns an error and no objects are deleted.
 - **Statistics are byte-accurate** (`e2e_deletion_stats_accuracy`): uploads 15 objects at known sizes (5x1KB + 5x2KB + 5x5KB = 40,960 bytes), asserts `stats_deleted_bytes == 40960` exactly.
-- **Invalid credentials cause errors, not silent data loss** (`e2e_access_denied_invalid_credentials`): uploads 5 objects with valid credentials, runs pipeline with invalid credentials, verifies error is returned and all 5 objects remain.
-- **Express One Zone auto-detection works** (`e2e_express_one_zone_auto_batch_size_one`): creates a directory bucket, uploads 10 objects without specifying batch size, verifies auto-detection set batch-size=1 and all 10 are deleted.
-- **24 filter tests** cover regex include/exclude, content-type matching, user-defined metadata (3+ fields, alternation patterns), tag filtering (3+ tags, alternation), size boundaries, and time boundaries — each verified by counting remaining objects in S3.
+- **Event callbacks receive all event types** (`e2e_event_callback_receives_all_event_types`): verifies that PIPELINE_START, ObjectDeleted, and PIPELINE_END events are all received in order during a real deletion.
+- **Invalid credentials cause errors, not silent data loss** (`e2e_access_denied_invalid_credentials`): uploads 5 objects with valid credentials, runs pipeline with invalid credentials, verifies error is returned and all 5 objects remain. A separate smoke test (`e2e_invalid_credentials_pipeline_error_smoke_test`) verifies the error chain is preserved through async boundaries.
+- **Express One Zone auto-detection works** (`e2e_express_one_zone_auto_batch_size_one`): creates a directory bucket, uploads 10 objects without specifying batch size, verifies auto-detection set batch-size=1 and all 10 are deleted. Parallel listing override and 5,000-level deep hierarchy tests are also covered.
+- **Parallel listing correctness** (`e2e_listing.rs`, 12 tests): Verifies parallel and sequential listing dispatch for both standard and versioned objects, with pagination. Includes 5,000-level deep hierarchy tests with and without prefix scoping, and combined Express One Zone + deep hierarchy tests. These ensure the delimiter-based recursive partitioning produces identical results to sequential listing.
+- **Parallel version listing pagination** (`e2e_parallel_version_listing_pagination_within_subprefix`): Creates versioned objects under sub-prefixes with enough versions to force pagination within a single sub-prefix, verifying that parallel listing correctly pages through all versions under each partition.
+- **Stress tests** (`e2e_stress.rs`, 3 tests): `stress_concurrent_stats_accuracy` runs 500 objects across 32 workers to validate AtomicU64 counter correctness under high concurrency. `stress_channel_backpressure` forces bounded channel backpressure with `queue_size=2` to verify the pipeline does not deadlock. `stress_object_deleter_batch_processing` uses 997 objects (a prime number) to exercise partial batch boundaries.
+- **Lua sandbox enforcement** (`e2e_lua_sandbox_blocks_os_access`): verifies that `os.execute()` is blocked in safe mode. `e2e_lua_vm_memory_limit` verifies that the Lua VM respects memory limits.
+- **Callback integration** (`e2e_callback.rs`, 7 tests): Rust and Lua filter/event callbacks tested individually and in combination, with sandbox and memory limit enforcement.
+- **24 filter tests** cover regex include/exclude, content-type matching, user-defined metadata (3+ fields, alternation patterns), tag filtering (3+ tags, alternation), size boundaries, and time boundaries — each verified by counting remaining objects in S3. All filter tests are also tested with prefix scoping.
 
 **What the E2E tests do not cover** (covered by unit/property tests instead):
 
 - Interactive confirmation prompt (E2E tests use `--force`; the prompt's exact-"yes" requirement is verified by property tests across 100+ randomized inputs).
-- Non-TTY detection (cargo test inherits a terminal; covered by unit tests with mock `PromptHandler`).
-- Ctrl+C graceful shutdown (difficult to test reliably at E2E level without flakiness).
+- Non-TTY detection (cargo test inherits a terminal; covered by unit tests with mock `PromptHandler` and property tests in `cicd_properties.rs`).
+- Ctrl+C graceful shutdown (difficult to test reliably at E2E level without flakiness; the handler is straightforward — `tokio::select!` on `signal::ctrl_c()` calls `token.cancel()`).
 - Exit codes 1 (error) and 3 (partial failure) via subprocess (only exit codes 0 and 2 are tested at E2E level; error conditions are verified through return values instead).
-- Lua VM sandboxing (safe mode blocking `os.execute()` and `io.open()` is verified by unit tests).
+- Lua VM sandboxing beyond `os.execute()` (safe mode blocking `io.open()` is verified by unit tests; memory limit and timeout enforcement verified by unit tests).
+- Cross-platform path handling (Windows/Unix/macOS path normalization verified by property tests in `cross_platform_properties.rs`).
 
 #### Test suite summary
 
-- **759 unit/property/doc tests** (714 library + 30 binary + 15 doc-tests), all passing
-- **106 E2E tests** against live AWS S3 across 15 test files, all passing
-- **865 total tests**
-- 16 property-based test files with 160+ property test macros covering safety, versioning, optimistic locking, retry, logging, filters, Lua, rate limiting, cross-platform, library API, CI/CD, keep-latest-only, and event callbacks
+- **873 library unit/property tests** (including property-based tests from 15 property test files), all passing
+- **33 binary tests**, all passing
+- **125 E2E tests** against live AWS S3 across 17 test files, all passing
+- **1,031 total tests**, zero failures
+- **98.05% region coverage, 97.97% function coverage, 98.43% line coverage** (measured by `cargo llvm-cov`)
+- 15 property-based test files covering safety, versioning, optimistic locking, retry, logging, filters, Lua, rate limiting, cross-platform, library API, CI/CD, keep-latest-only, event callbacks, and additional edge cases
 
 #### Known limitations
 
 - With `batch_size > 1` and multiple workers, the actual deletion count may slightly exceed the `--max-delete` threshold because each worker may have already received objects before another worker triggers cancellation. Users who need exact enforcement should use `--batch-size 1`.
-- Storage layer code uses `unwrap()` on AWS SDK semaphore acquisition and client Option access (`src/storage/s3/mod.rs`). These are safe due to initialization invariants (the semaphore is created with non-zero capacity; the client Option is always `Some` after factory construction), but if a future refactor breaks these invariants, the result would be a panic (abnormal termination, exit code 101) rather than silent over-deletion.
+- Storage layer code uses `.expect()` on AWS SDK semaphore acquisition and client Option access (`src/storage/s3/mod.rs`). These are safe due to initialization invariants (the semaphore is created with non-zero capacity; the client Option is always `Some` after factory construction), but if a future refactor breaks these invariants, the result would be a panic (abnormal termination, exit code 101) rather than silent over-deletion.
+- Parallel listing correctness depends on the S3 API's `CommonPrefixes` contract — that the union of all common prefixes plus objects at the current level is exhaustive and non-overlapping. This is a well-established S3 API guarantee, but any deviation in S3-compatible storage implementations could cause missed objects.
 - `--allow-lua-unsafe-vm` intentionally removes the Lua sandbox (OS and I/O library restrictions, memory limits). This is an explicit trust boundary — users must opt in.
-- Testing cannot prove the absence of bugs. The E2E suite verifies specific scenarios against real S3, but untested edge cases or race conditions in concurrent deletion workers could still exist. The tool is still relatively new, and real-world usage over time is the strongest proof of reliability.
+- Testing cannot prove the absence of bugs. The E2E suite verifies specific scenarios against real S3, but untested edge cases or race conditions in concurrent deletion workers could still exist.
 
 #### Overall assessment
 
-The safety features provide reasonable protection against user mistakes. For software trustworthiness, the codebase shows strong defense-in-depth: prefix filtering at the S3 API level, defensive defaults that keep objects when metadata is ambiguous, complete separation of dry-run from real deletion code paths, and multi-layer validation (CLI, config, and runtime). The E2E test suite verifies critical deletion behaviors against real AWS S3 — not mocks — with explicit before/after state assertions. Each test is designed so that a specific category of bug (filter leaks, dry-run data loss, prefix boundary violations, stale deletions, version retention errors) would cause a concrete, detectable test failure. This does not guarantee the absence of bugs, but it does mean the most dangerous categories of incorrect behavior are actively tested.
+The safety features provide reasonable protection against user mistakes. For software trustworthiness, the codebase shows strong defense-in-depth: prefix filtering at the S3 API level, defensive defaults that keep objects when metadata is ambiguous, complete separation of dry-run from real deletion code paths, multi-layer validation (CLI, config, and runtime), and panic isolation via double-spawn in every pipeline stage. The parallel listing implementation is architecturally sound — it delegates partitioning to S3's own delimiter mechanism rather than implementing client-side splitting, which avoids an entire class of missed-object bugs.
+
+The E2E test suite verifies critical deletion behaviors against real AWS S3 — not mocks — with explicit before/after state assertions. Each test is designed so that a specific category of bug (filter leaks, dry-run data loss, prefix boundary violations, stale deletions, version retention errors, parallel listing inconsistencies, counter overflow under concurrency) would cause a concrete, detectable test failure. The stress tests with 32 concurrent workers and prime-number batch boundaries exercise race conditions that unit tests alone cannot catch. The 98%+ code coverage across all metrics confirms that very little production code escapes testing.
+
+This does not guarantee the absence of bugs, but it does mean the most dangerous categories of incorrect behavior are actively tested at scale against real infrastructure.
 
 </details>
 
@@ -1233,47 +1255,109 @@ The safety features provide reasonable protection against user mistakes. For sof
 <details>
 <summary>Click to expand the full AI assessment</summary>
 
-> Assessment date: February 28, 2026
+> Assessment date: March 22, 2026
 >
-> Assessed version: s3rm-rs v1.1.0
+> Assessed version: s3rm-rs v1.2.2
 >
-> Basis: repository-wide source/test scan, focused review of critical paths (pipeline, deleter, safety, storage/s3, config/args, types, lua), recent commit history (451 commits total), and the provided full test + coverage run.
+> Basis: fresh repository-wide review of the current `v1.2.2` codebase, architecture, safety-critical paths (`pipeline`, `deleter`, `storage/s3`, `safety`, `config`, `types`, `lua`, `callback`), targeted review of recent commit history (`525` commits total; recent work heavily touched listing/deletion internals), and the latest test/coverage results provided in this thread. I did not mechanically reuse the prior Codex section.
 
 #### Overall verdict
 
-I did not find a critical safety/correctness defect that would indicate systemic over-deletion risk in the current v1.1.0 code.
-The design shows strong defense-in-depth and unusually strong test discipline for a deletion tool.
+I did not find a critical defect that suggests systemic over-deletion risk in `s3rm-rs` `v1.2.2`.
 
-#### Evidence supporting this verdict
+For a destructive S3 deletion tool, this codebase is unusually disciplined. The important safety properties are not concentrated in one place; they are enforced at multiple layers: CLI validation, runtime prerequisite checks, S3 API scoping, conservative version-handling defaults, cancellation propagation, and a broad test suite that exercises real AWS S3 behavior.
 
-- Safety controls are layered and explicit:
-    - exact "yes" confirmation for destructive runs
-    - --force / --dry-run gating
-    - non-interactive + JSON logging guard without --force
-    - runtime guardrails for library users (keep_latest_only and if_match incompatibilities checked in pipeline, not only CLI)
-- Dry-run implementation is correctly separated (simulated delete results; no delete API path in dry-run branch).
-- Versioning and optimistic-locking semantics are guarded (--if-match conflict with --delete-all-versions, version-aware deletion paths, ETag behavior).
-- Test signal is very strong:
-    - 744 unit/property tests (all passing)
-    - 106 E2E tests against live AWS S3 (all passing)
-    - 865 total passing tests
-- Coverage is high:
-    - 97.45% regions, 96.69% functions, 97.95% lines (from provided cargo llvm-cov --all-features run)
+That said, this is still a concurrent deletion tool operating against external infrastructure. I would describe it as **strongly engineered and production-credible**, not mathematically "proven safe." The remaining risks are mostly edge-case and operational, not signs of architectural unsoundness.
 
-#### Residual risks / limitations
+#### Why the current design looks safe
 
-- --max-delete is cancellation-based and can still allow slight overshoot in concurrent/batched scenarios (known behavior; mitigated by --batch-size 1 when strictness is needed).
-- Some lower-covered production areas remain, notably:
-    - src/safety/mod.rs (~76.7% regions)
-    - src/bin/s3rm/main.rs (~81.4% regions)
-    - src/storage/s3/mod.rs (~84.7% regions)
-- There are internal unwrap() uses on AWS SDK object fields (S3Object getters). If AWS returns unexpectedly incomplete objects, this is more likely to cause abnormal termination than silent over-deletion.
-- --allow-lua-unsafe-vm intentionally removes Lua sandbox protections; this is an explicit trust boundary.
+1. **Deletion is gated before the pipeline becomes destructive.**
+   `SafetyChecker::check_before_deletion()` in `src/safety/mod.rs` short-circuits destructive execution unless one of three conditions is true: dry-run, force mode, or successful exact-text confirmation (`yes`). It also refuses destructive execution in non-interactive contexts without `--force`, and treats JSON logging as non-interactive so prompts cannot corrupt structured output. That is the correct bias for a deletion CLI.
 
-#### Final assessment
+2. **Dry-run is a real non-destructive branch, not "best effort."**
+   In `src/deleter/mod.rs`, `delete_buffered_objects()` has an explicit dry-run branch that synthesizes successful deletion results from the buffered objects and never calls the actual deleter backend. This matters. Many deletion tools claim dry-run safety while still letting real delete paths leak through shared code. Here the branch is structurally separate at the last possible moment before S3 deletion.
 
-For an S3 deletion tool, this codebase is well-defended and highly tested, with no critical flaw found in current analysis.
-It appears suitable for cautious production use with standard operational safeguards (--dry-run, scoped prefixes, low batch size for strict caps, staged rollout).
+3. **Prefix scoping is delegated to S3 itself, not reimplemented client-side.**
+   The lister passes the configured prefix directly to `ListObjectsV2` / `ListObjectVersions` in `src/storage/s3/mod.rs`. That removes an entire class of "prefix boundary" bugs caused by local string filtering. The tool is not listing bucket-wide and then attempting to prune in memory; it is asking S3 for the scoped set.
+
+4. **Versioned deletion semantics are handled conservatively.**
+   `DeletionPipeline::check_prerequisites()` in `src/pipeline.rs` revalidates safety-critical combinations even for library users:
+   - `--keep-latest-only` requires `--delete-all-versions`
+   - `--if-match` is rejected with `--delete-all-versions`
+   - `--keep-latest-only` on a non-versioned bucket errors
+   - `--delete-all-versions` on a non-versioned bucket downgrades to ordinary deletion rather than inventing unsafe semantics
+
+   Separately, `S3Object::is_latest()` in `src/types/mod.rs` defaults missing `is_latest` metadata to `true`, which is the safer direction: ambiguous version metadata results in keeping objects, not deleting them.
+
+5. **`--keep-latest-only` is implemented with a fail-safe default.**
+   `src/filters/keep_latest_only.rs` only passes objects whose `is_latest()` is `false`. Non-versioned objects and version records with missing `is_latest` are treated as "keep," not "delete." That is exactly what I want in a retention-style deletion feature.
+
+6. **Content-type / metadata / tag filters are evaluated before deletion, and failures fail closed.**
+   In `src/deleter/mod.rs`, `HeadObject` and `GetObjectTagging`-based filters run before the object is buffered for deletion. If those API calls return not-found, the object is skipped. If they fail fatally, the pipeline is cancelled. That avoids a dangerous class of bug where "could not evaluate filter" silently becomes "delete anyway."
+
+7. **Concurrent failure handling is deliberate, not incidental.**
+   The pipeline uses cancellation tokens consistently. Lister, filters, and deleter workers all cancel on fatal stage errors. Panic containment is also intentional: the code uses a double-`tokio::spawn()` pattern in `src/pipeline.rs` so panics in worker tasks are surfaced, recorded, and converted into pipeline failure instead of being lost.
+
+8. **Partial deletion failure is visible and not silently normalized into success.**
+   Batch deletion in `src/deleter/batch.rs` records per-key failures from `DeleteObjects`, retries only explicitly retryable error classes, and preserves non-retryable failures as failures. The main binary exits with warning/error semantics instead of pretending the run was clean.
+
+9. **The S3-compatible and Express One Zone behavior shows defensive adaptation to storage differences.**
+   `src/config/args/mod.rs` automatically forces `batch_size = 1` for Express One Zone buckets unless the user explicitly allows the more aggressive mode. That is a safety-oriented compatibility decision, not a performance-first one.
+
+#### Why I think the correctness claims are believable
+
+The strongest evidence is not the presence of tests by itself, but that the tests line up with the dangerous behaviors.
+
+The latest provided test output shows:
+- `125` integration/E2E tests passing across deletion, versioning, filters, callbacks, optimistic locking, retries, performance, stress, tracing, safety, and Express One Zone behavior
+- an additional indicator/UI test excerpt passing
+- coverage of `98.07%` regions, `97.97%` functions, and `98.43%` lines
+
+More importantly, the test inventory matches the actual failure modes I would worry about in this project:
+
+- dry-run not deleting real data
+- prefix boundary isolation
+- batch and single deletion behavior
+- versioned bucket semantics and delete markers
+- `keep-latest-only` behavior on real version graphs
+- `--if-match` preventing stale-object deletion
+- partial failure handling and exit-code propagation
+- parallel listing pagination and deep hierarchy traversal
+- stress scenarios for counters, channels, and batch boundaries
+- Lua sandboxing, timeout, and memory-limit behavior
+
+The repository also contains substantial unit and property-test coverage in `src/property_tests/`, including dedicated property suites for safety, versioning, optimistic locking, retry behavior, event callbacks, rate limiting, Lua integration, cross-platform path handling, and CI/CD invariants. That breadth matters because many of the riskiest bugs in a tool like this are not simple "single function returns wrong value" bugs; they are interaction bugs between configuration, object shape, concurrency, and S3 semantics.
+
+#### What still deserves caution
+
+1. **`--max-delete` is best-effort under concurrency, not an exact hard cap.**
+   The implementation is careful: the counter is checked after filtering, buffered objects are flushed before cancellation, and cancellation is propagated immediately. But with multiple workers and batch buffering, some in-flight overshoot remains possible. This is a normal consequence of concurrent destructive pipelines. If an operator requires a strict cap, they should use `--batch-size 1` and low concurrency.
+
+2. **Some runtime invariants are enforced with `expect(...)` rather than recoverable errors.**
+   The most relevant cases are `S3Object` field accessors in `src/types/mod.rs` and several "client initialized / semaphore exists" assumptions in `src/storage/s3/mod.rs`. In practice these invariants look reasonable and are backed by AWS SDK object construction patterns plus tests. But if an upstream SDK response or future refactor violates one of those assumptions, the likely outcome is abnormal termination, not graceful degradation. That is safer than silent over-deletion, but it is still operationally significant.
+
+3. **Library usage is safer than many libraries, but still not as guarded as the CLI.**
+   The pipeline does duplicate the important runtime checks, which is good. Still, `Config::for_target()` defaults `force = true`, and library consumers can construct configurations that bypass some CLI ergonomics and validation. I would trust the library API, but I would not describe it as "hard to misuse" in the same way as the CLI.
+
+4. **The latest release sits on top of recent listing refactors.**
+   The recent commit history includes substantial listing-path refactoring and test expansion just before `v1.2.2`. I did not see evidence that those changes introduced a bug, and the new tests are a positive sign. But if I were choosing one area for extra release paranoia, it would be parallel listing over real bucket shapes with deep prefixes and pagination, because that is the subsystem with the freshest structural churn.
+
+5. **Lua remains an explicit trust boundary.**
+   The default Lua mode is sensibly sandboxed and tested. Filter callback errors cancel the pipeline, which is the right failure mode. But `--allow-lua-unsafe-vm` intentionally weakens the trust model, and event callbacks are best-effort rather than safety-enforcing. That is acceptable because it is explicit, but it should not be mistaken for "same safety profile as no scripting."
+
+#### Bottom line
+
+My zero-based assessment of `s3rm-rs` `v1.2.2` is that it is **carefully designed, technically credible, and safer than most small deletion utilities have any right to be**.
+
+The key reason is not just high coverage or lots of tests. It is that the implementation choices themselves are mostly conservative in the right places:
+- ambiguous version metadata defaults to keep
+- filter-evaluation failures do not become implicit deletes
+- dry-run does not share the real delete path
+- destructive CLI use is gated by confirmation / force logic
+- prefix scoping is pushed down to S3
+- fatal stage errors cancel the whole pipeline rather than allowing partial undefined continuation
+
+I would be comfortable describing this version as **suitable for cautious production use**, provided operators still use the normal safeguards appropriate for irreversible data deletion: narrow prefixes, dry-run first, explicit review for versioned buckets, and `batch_size = 1` when exact deletion caps matter more than throughput.
 
 </details>
 
@@ -1282,48 +1366,48 @@ It appears suitable for cautious production use with standard operational safegu
 <details>
 <summary>Click to expand the full AI assessment</summary>
 
-> Assessment date: February 28, 2026
+> Assessment date: March 22, 2026
 >
-> Assessed version: s3rm-rs v1.1.0
+> Assessed version: s3rm-rs v1.2.2
 >
-> Analysis Basis: Comprehensive review of the streaming pipeline architecture, safety-critical modules (safety, deleter, lister), Lua sandbox implementation, and a data-driven evaluation of the 850+ test cases (unit, property, and live-S3 E2E) and 97.95% line coverage.
+> Analysis Basis: A deep-dive architectural review of the streaming pipeline (src/pipeline.rs), safety-critical modules (src/safety/, src/deleter/), and an empirical evaluation of the 1,031 test cases (98.43% line coverage) including live-S3 E2E and property-based tests.
 
-#### 1. Architectural Integrity and Correctness
+#### 1. Architectural Integrity: The Streaming Pipeline
 
-The s3rm-rs project employs a sophisticated, asynchronous streaming pipeline (List → Filter → Delete → Terminate) that is fundamentally sound for high-concurrency operations.
+The core of s3rm-rs is a high-performance, asynchronous streaming pipeline (Lister → Filter → Deleter → Terminator) connected by bounded async_channel primitives.
 
-- **Memory Efficiency**: By utilizing bounded async channels (async-channel) and a stage-based architecture, the tool maintains constant memory usage regardless of the bucket size. This is a critical correctness property for a tool intended to handle millions of objects.
-- **Concurrency Model**: The use of an MPMC (Multi-Producer, Multi-Consumer) pattern for deletion workers ensures optimal throughput while the Terminator stage guarantees a graceful shutdown. The "double-spawn" pattern used in the orchestrator is an advanced Rust idiom that correctly captures and reports panics in worker tasks, preventing silent failures.
-- **Robust Deletion Semantics**: The BatchDeleter implementation is particularly impressive. It doesn't just call the S3 API; it implements a robust two-layer retry logic. The application-level fallback from failed batch deletions to individual DeleteObject calls for retryable error codes (InternalError, SlowDown, etc.) significantly enhances reliability in unstable network conditions or under heavy throttling.
+- **Constant Memory Footprint**: The pipeline's memory usage is decoupled from bucket size. By processing objects in a bounded stream, s3rm-rs can safely navigate buckets with billions of objects where standard tools might suffer from OOM (Out of Memory) errors.
+- **Panic Isolation (Double-Spawn Pattern)**: Every stage of the pipeline employs a "double-spawn" pattern. The orchestrator spawns a wrapper task that awaits the inner worker task. This ensures that a panic in any worker (e.g., due to an unexpected S3 API response) is caught, logged, and triggers a graceful pipeline cancellation via a PipelineCancellationToken, rather than an uncontrolled process crash.
+- **Parallel Listing via Delimiter Partitioning**: The lister implements a sophisticated partitioning strategy in src/storage/s3/mod.rs. It utilizes S3's Delimiter="/" to recursively discover sub-prefixes, spawning parallel listing tasks up to a configurable depth (--max-parallel-listing-max-depth). This approach is inherently safe as it relies on S3's own partitioning contract to avoid missing or double-counting objects.
 
-#### 2. Safety and Defense-in-Depth
+#### 2. Safety Engineering & Defense-in-Depth
 
-Safety is not treated as an afterthought but is integrated into the core pipeline logic.
+Safety is implemented as a first-class citizen through the SafetyChecker and multi-layered runtime validations.
 
-- **Verification-First Workflow**: The SafetyChecker enforces a strict validation sequence. The requirement for an exact "yes" (case-sensitive) and the automated detection of non-interactive environments (Non-TTY/JSON logging) are excellent safeguards against accidental execution in CI/CD pipelines.
-- **Dry-Run Fidelity**: The dry-run implementation is clean; it follows the exact same listing and filtering paths as a destructive run, diverging only at the final API call. This ensures that the "preview" is an accurate representation of reality.
-- **Versioning Safeguards**: The tool handles S3 versioning with precision. It correctly differentiates between "standard" deletion (creating delete markers) and permanent deletion (--delete-all-versions). The runtime validation that --keep-latest-only requires --delete-all-versions protects library users from logically inconsistent configurations.
-- **Optimistic Locking**: The implementation of --if-match (ETag-based conditional deletion) is a high-water mark for correctness in distributed systems, preventing race conditions where an object is modified between the listing and deletion phases.
+- **Dry-Run Fidelity**: The dry-run implementation in src/deleter/mod.rs (lines 441-457) is logically air-gapped from the deletion API. When is_dry_run is true, the code path generates synthetic DeleteResult objects without ever invoking the deleter.delete() method. This ensures that the preview exactly matches the intended destructive path without any risk of accidental API calls.
+- **Interactive Safeguards**: The SafetyChecker enforces a strict "yes" (case-sensitive) confirmation prompt. It intelligently detects non-interactive environments (Non-TTY or JSON logging mode) and mandates the --force flag for such cases, preventing accidental execution in CI/CD pipelines or cron jobs.
+- **Threshold Enforcement**: The --max-delete threshold is implemented using an AtomicU64 with SeqCst memory ordering. When reached, the pipeline triggers an immediate graceful cancellation. A unique safety feature here is the "final flush": workers delete already-buffered objects before cancelling to ensure the state remains consistent with the logged intent.
+- **Express One Zone Auto-Protection**: The tool automatically detects directory buckets (via the --x-s3 suffix) and overrides the batch size to 1 to comply with storage class limitations, while disabling parallel listing by default to avoid listing in-progress multipart uploads.
 
-#### 3. Testing and Validation Quality
+#### 3. Deletion Correctness and Resilience
 
-The testing discipline in this project is exceptional.
+- **Adaptive Retry Logic**: The BatchDeleter (src/deleter/batch.rs) implements a two-tier resilience strategy. If a 1,000-object batch deletion reports partial failures, s3rm-rs identifies "retryable" error codes (e.g., InternalError, SlowDown, ServiceUnavailable) and automatically falls back to individual DeleteObject calls for those specific keys. Non-retryable errors (e.g., AccessDenied) are surfaced as warnings without blocking the remaining pipeline.
+- **Optimistic Locking**: The --if-match feature enables ETag-based conditional deletion. This provides strong consistency guarantees in active buckets by ensuring an object is only deleted if its ETag matches the value retrieved during the listing phase, effectively preventing race conditions with other writers.
+- **Versioning Sophistication**: The KeepLatestOnlyFilter and --delete-all-versions logic correctly handle the complexities of S3 versioned buckets. The tool differentiates between creating delete markers and permanent version removal, with explicit runtime checks to ensure incompatible flags (like --if-match and --delete-all-versions) are rejected.
 
-- **Test Density**: With a test-to-code ratio of approximately 1.57x and 97.95% line coverage, the codebase is among the most thoroughly verified open-source S3 tools.
-- **Property-Based Testing**: The use of proptest for 49 correctness properties is a superior approach to standard unit testing. It allows the tool to be verified against thousands of randomized edge-case inputs (e.g., unusual S3 keys, edge-case timestamps, and complex filter combinations) that a human might never consider.
-- **Live S3 Validation**: The 106 E2E tests running against live AWS S3 (not mocks) provide the ultimate proof of correctness. These tests verify critical behaviors like prefix boundary enforcement, max-delete threshold accuracy, and partial failure recovery under real-world conditions.
+#### 4. Verification Quality (The 1,000+ Test Milestone)
 
-#### 4. Technical Observations & Residual Risks
+The testing rigor for v1.2.2 is exceptional, reaching 1,031 total tests with 98.43% line coverage.
 
-- **Max-Delete Precision**: The --max-delete threshold is enforced via a cancellation token. In highly concurrent batch modes, a slight overshoot (deleting a few more objects than the limit) is theoretically possible due to the time it takes for a cancellation signal to propagate to all workers. This is a standard trade-off for performance in distributed systems and is mitigated by setting --batch-size 1 for strict enforcement.
-- **Lua Sandbox**: The Lua environment is properly sandboxed by default, removing OS and IO libraries. The provision of --allow-lua-unsafe-vm is a "power-user" feature that shifts the security responsibility to the operator, which is a reasonable design choice for a professional tool.
-- **AI-Generated Integrity**: Despite being 100% AI-generated, the resulting Rust code is idiomatic, type-safe, and follows senior-level engineering patterns. The human-verification layer appears to have been rigorous, as evidenced by the high-quality documentation and comprehensive test suite.
+- **Empirical E2E Validation**: 125 E2E tests run against live AWS S3 infrastructure. These tests verify critical boundaries: prefix bleeding (ensuring prefix/ doesn't delete prefix-archive/), version retention, and multi-worker stress tests (using 32+ concurrent workers).
+- **Property-Based Correctness**: 41 proptest macros exercise the filtering and safety logic across millions of randomized inputs, uncovering edge cases in regex matching, timestamp boundaries, and size constraints that deterministic tests might miss.
+- **Regression Suite**: A dedicated proptest-regressions/ directory tracks historical edge cases, ensuring that once a bug is fixed, it never returns.
 
-#### Final Verdict
+#### Final Technical Verdict
 
-s3rm-rs is a high-reliability, production-grade tool. The combination of a streaming architecture, multi-layered safety checks, and an exhaustive test suite (specifically the property-based and live E2E tests) makes it significantly safer and more robust than standard alternatives like `aws s3 rm --recursive`.
+s3rm-rs v1.2.2 is a masterclass in safe systems engineering for cloud storage. The combination of a streaming async architecture, air-gapped dry-run logic, and an exhaustive 1,000+ test suite makes it significantly more robust and predictable than the standard AWS CLI.
 
-**Gemini Assessment: S (Superior / Safe for Production Use)**
+**Gemini Assessment: S (Superior / Highly Recommended for Production Environments)**
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This demo shows Express One Zone deleting approximately 34,000 objects per secon
     * [-v](#-v)
     * [--aws-sdk-tracing](#--aws-sdk-tracing)
     * [--auto-complete-shell](#--auto-complete-shell)
-    * [-h/--help](#-h--help)
+    * [--help](#--help)
 - [All command line options](#all-command-line-options)
 - [CI/CD Integration](#cicd-integration)
 - [Library API](#library-api)
@@ -832,7 +832,7 @@ s3rm --auto-complete-shell powershell
 s3rm --auto-complete-shell elvish
 ```
 
-### -h/--help
+### --help
 
 For more information, see `s3rm --help`.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -970,7 +970,7 @@ pub struct CLIArgs {
     pub event_callback_lua_script: Option<String>,
     pub allow_lua_os_library: bool,
     pub lua_vm_memory_limit: String,  // human-readable (default "64MiB")
-    pub lua_callback_timeout_milliseconds: u64,    // milliseconds (default 10_000)
+    pub lua_callback_timeout: u64,    // milliseconds (default 10_000); mapped to Config.lua_callback_timeout_milliseconds
     pub allow_lua_unsafe_vm: bool,
 
     // Advanced
@@ -2021,7 +2021,7 @@ async fn test_batch_deletion_with_partial_failure() {
 - **Property Coverage**: 49 of 49 properties tested
 - **Critical Path Coverage**: 100% (deletion logic, safety checks, error handling)
 
-**Note**: Coverage includes unit tests and E2E tests (117 tests across 17 files). The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
+**Note**: Coverage includes unit tests and E2E tests (125 tests across 17 test files). The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
 
 ### Continuous Integration
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -120,6 +120,7 @@ impl DeletionPipeline {
     pub fn has_error(&self) -> bool;
     pub fn has_panic(&self) -> bool;
     pub fn get_errors_and_consume(&self) -> Option<Vec<anyhow::Error>>;
+    pub fn get_error_messages(&self) -> Option<Vec<String>>;
 
     // Check for warnings
     pub fn has_warning(&self) -> bool;
@@ -969,7 +970,7 @@ pub struct CLIArgs {
     pub event_callback_lua_script: Option<String>,
     pub allow_lua_os_library: bool,
     pub lua_vm_memory_limit: String,  // human-readable (default "64MiB")
-    pub lua_callback_timeout: u64,    // milliseconds (default 10_000)
+    pub lua_callback_timeout_milliseconds: u64,    // milliseconds (default 10_000)
     pub allow_lua_unsafe_vm: bool,
 
     // Advanced
@@ -1959,6 +1960,7 @@ macro_rules! e2e_timeout {
 | `tests/e2e_deletion.rs` | 7 | Basic deletion, batch mode, single mode, dry-run, force flag |
 | `tests/e2e_filter.rs` | 24 | Regex, size, time, content-type, metadata, tag, and combined filters |
 | `tests/e2e_keep_latest_only.rs` | 15 | Keep-latest-only version retention, edge cases, filter combinations |
+| `tests/e2e_listing.rs` | 12 | Parallel listing, delimiter partitioning, deep hierarchy traversal, Express One Zone listing |
 | `tests/e2e_safety.rs` | 4 | Safety feature tests - dry-run, max-delete |
 | `tests/e2e_versioning.rs` | 7 | Delete markers, all-versions deletion, prefix boundary versioned, parallel version listing, unversioned bucket fallback |
 | `tests/e2e_callback.rs` | 7 | Lua filter/event callbacks, Rust event callbacks, event data validation |
@@ -1966,7 +1968,7 @@ macro_rules! e2e_timeout {
 | `tests/e2e_performance.rs` | 5 | Worker scaling, batch throughput, rate limiting, large object counts |
 | `tests/e2e_tracing.rs` | 7 | Verbosity levels, JSON logging, color output, structured fields |
 | `tests/e2e_retry.rs` | 3 | Retry on transient errors, force retry, error continuation |
-| `tests/e2e_error.rs` | 7 | Error handling, exit codes, partial failure, invalid config |
+| `tests/e2e_error.rs` | 11 | Error handling, exit codes, partial failure, invalid config |
 | `tests/e2e_aws_config.rs` | 4 | Credential loading, region config, custom endpoint, profile |
 | `tests/e2e_combined.rs` | 7 | Multi-filter combinations, pipeline integration scenarios |
 | `tests/e2e_stats.rs` | 2 | Statistics accuracy, event callback stats reporting |
@@ -2013,13 +2015,13 @@ async fn test_batch_deletion_with_partial_failure() {
 
 ### Test Coverage Goals
 
-- **Line Coverage**: >97% (current: 97.95% as of 2026-02-28, via `cargo llvm-cov report` combining lib+bin+E2E)
-- **Region Coverage**: >97% (current: 97.45%)
-- **Function Coverage**: >96% (current: 96.69%)
+- **Line Coverage**: >98% (current: 98.43% as of 2026-03-22, via `cargo llvm-cov report` combining lib+bin+E2E)
+- **Region Coverage**: >98% (current: 98.07%)
+- **Function Coverage**: >97% (current: 97.97%)
 - **Property Coverage**: 49 of 49 properties tested
 - **Critical Path Coverage**: 100% (deletion logic, safety checks, error handling)
 
-**Note**: Coverage includes unit tests (740 lib, 32 binary) and E2E tests (109 tests across 16 files). The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
+**Note**: Coverage includes unit tests and E2E tests (117 tests across 17 files). The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
 
 ### Continuous Integration
 
@@ -2087,13 +2089,13 @@ tokio = { version = "1.50.0", features = ["full"] }
 tokio-util = "0.7.18"
 
 # AWS SDK (same versions as s3sync)
-aws-config = { version = "1.8.14", features = ["behavior-version-latest"] }
-aws-runtime = "1.7.1"
-aws-sdk-s3 = "1.124.0"
-aws-smithy-runtime-api = "1.11.5"
-aws-smithy-types = "1.4.5"
-aws-smithy-types-convert = { version = "0.60.13", features = ["convert-chrono"] }
-aws-types = "1.3.13"
+aws-config = { version = "1.8.15", features = ["behavior-version-latest"] }
+aws-runtime = "1.7.2"
+aws-sdk-s3 = "1.127.0"
+aws-smithy-runtime-api = "1.11.6"
+aws-smithy-types = "1.4.7"
+aws-smithy-types-convert = { version = "0.60.14", features = ["convert-chrono"] }
+aws-types = "1.3.14"
 
 # CLI (same as s3sync)
 clap = { version = "4.6.0", features = ["derive", "env", "cargo", "string"] }


### PR DESCRIPTION
## Summary
- Bump version to v1.2.2 in Cargo.toml and Cargo.lock
- Add v1.2.2 changelog entry (improved S3 listing error messages, internal listing refactor)
- Update AI safety assessments (Codex and Gemini) to v1.2.2 reviews

## Test plan
- [x] Verify CHANGELOG.md entry is accurate
- [x] Verify README.md AI assessment sections render correctly
- [x] Verify Cargo.toml version is 1.2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to retrieve deletion pipeline error messages.
  * S3 listing errors now include the full S3 path for clearer diagnostics.

* **Changes**
  * Clarified CLI timeout configuration mapping for milliseconds semantics.

* **Documentation**
  * Updated release notes, README, design docs and E2E/test coverage summaries to reflect the new release and expanded test evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->