### PR TITLE
Add --filter-delete-marker-only and bump to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.0] - 2026-04-14
+
+### Added
+
+- `--filter-delete-marker-only` option to delete only delete markers while leaving all object versions intact (requires `--delete-all-versions`). Useful for "undeleting" objects by removing delete markers so underlying versions become visible again. Can be combined with other filters like `--filter-include-regex`
+- E2E tests for delete-marker-only filtering across 8 scenarios (`tests/e2e_delete_marker_only.rs`)
+
+### Changed
+
+- Updated dependencies: `tokio` 1.50→1.51, `aws-sdk-s3` 1.127→1.129, `clap_complete` 4.6.0→4.6.2, `uuid` 1.22→1.23, plus 36 transitive dependency updates
+
 ## [v1.2.2] - 2026-03-22
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,9 @@ S3 object deletion tool built in Rust. Library-first design with streaming pipel
 
 ## Absolute Rules
 
+- **Nerver commit**
 - **No unsolicited refactoring** — only refactor when explicitly asked
 - **No unsolicited test changes** — confirm before modifying any tests
-- **No autonomous commits** — never run `git commit` without explicit human approval
-- **No auto `/check-commit-push`** — only run when the user explicitly asks
 
 ## Build & Verify
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,10 @@ S3 object deletion tool built in Rust. Library-first design with streaming pipel
 
 ## Absolute Rules
 
-- **Nerver commit**
 - **No unsolicited refactoring** — only refactor when explicitly asked
 - **No unsolicited test changes** — confirm before modifying any tests
+- **No autonomous commits** — never run `git commit` without explicit human approval
+- **No auto `/check-commit-push`** — only run when the user explicitly asks
 
 ## Build & Verify
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.127.0"
+version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "151783f64e0dcddeb4965d08e36c276b4400a46caa88805a2e36d497deaf031a"
+checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -442,13 +442,13 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.8",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -748,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -817,9 +817,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -844,9 +844,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -1386,6 +1386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1513,7 +1519,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1536,16 +1541,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -1563,7 +1567,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1600,12 +1604,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1613,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1626,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1640,15 +1645,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1660,15 +1665,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1708,12 +1713,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1767,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1800,9 +1805,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libgit2-sys"
@@ -1836,9 +1841,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1857,9 +1862,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -1910,9 +1915,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1973,9 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2110,9 +2115,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2473,14 +2478,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -2518,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2554,7 +2559,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2680,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2994,9 +2999,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3019,9 +3024,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -3036,9 +3041,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3061,7 +3066,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -3317,9 +3322,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3394,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3407,9 +3412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3417,9 +3422,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3430,9 +3435,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3730,9 +3735,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -3751,9 +3756,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3762,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3794,18 +3799,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3832,9 +3837,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3843,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3854,9 +3859,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."
@@ -34,13 +34,13 @@ thiserror = "2.0.18"
 # Async runtime (same as s3sync)
 async-trait = "0.1.89"
 async-channel = "2.5.0"
-tokio = { version = "1.50.0", features = ["full"] }
+tokio = { version = "1.51.1", features = ["full"] }
 tokio-util = "0.7.18"
 
 # AWS SDK (same versions as s3sync)
 aws-config = { version = "1.8.15", features = ["behavior-version-latest"] }
 aws-runtime = "1.7.2"
-aws-sdk-s3 = "1.127.0"
+aws-sdk-s3 = "1.129.0"
 aws-smithy-runtime-api = "1.11.6"
 aws-smithy-types = "1.4.7"
 aws-smithy-types-convert = { version = "0.60.14", features = ["convert-chrono"] }
@@ -48,7 +48,7 @@ aws-types = "1.3.14"
 
 # CLI (same as s3sync)
 clap = { version = "4.6.0", features = ["derive", "env", "cargo", "string"] }
-clap_complete = "4.6.0"
+clap_complete = "4.6.2"
 clap-verbosity-flag = "3.0.4"
 
 # Date/time
@@ -97,7 +97,7 @@ shadow-rs = { version = "1.7.1", optional = true }
 [dev-dependencies]
 proptest = "1.11"
 once_cell = "1.21.4"
-uuid = { version = "1.22.0", features = ["v4"] }
+uuid = { version = "1.23.0", features = ["v4"] }
 nix = { version = "0.31.2", features = ["process", "signal"] }
 tempfile = "3.27.0"
 rusty-fork = "0.3.1"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This demo shows Express One Zone deleting approximately 34,000 objects per secon
     * [Combined filters](#combined-filters)
     * [Delete all versions](#delete-all-versions)
     * [Keep only latest versions](#keep-only-latest-versions)
+    * [Delete only delete markers](#delete-only-delete-markers)
     * [Set a deletion limit](#set-a-deletion-limit)
     * [Custom endpoint](#custom-endpoint)
     * [Specify credentials](#specify-credentials)
@@ -171,6 +172,7 @@ S3 versioned buckets store multiple versions of each object. s3rm handles all sc
 - **Default behavior** — creates delete markers (objects appear deleted but previous versions are preserved)
 - **`--delete-all-versions`** — permanently removes every version of matching objects, including delete markers
 - **`--keep-latest-only`** — retains only the latest version of each object, deleting all older versions (requires `--delete-all-versions`)
+- **`--filter-delete-marker-only`** — deletes only delete markers, leaving all object versions intact (requires `--delete-all-versions`)
 
 ### S3 Express One Zone support
 
@@ -542,6 +544,16 @@ s3rm --keep-latest-only --delete-all-versions --force s3://my-bucket/data/
 
 This is useful for enforcing version retention policies — it cleans up old versions while preserving the current state of every object. Can be combined with `--filter-include-regex` or `--filter-exclude-regex` to target specific keys.
 
+### Delete only delete markers
+
+On versioned buckets, delete only the delete markers while leaving all object versions intact:
+
+```bash
+s3rm --filter-delete-marker-only --delete-all-versions --force s3://my-bucket/data/
+```
+
+This is useful for "undeleting" objects — removing the delete markers makes the underlying object versions visible again. Can be combined with other filters like `--filter-include-regex` to target specific keys.
+
 ### Set a deletion limit
 
 Stop after deleting 1,000 objects (safety net for large buckets):
@@ -620,20 +632,21 @@ If an object fails after all retries are exhausted, s3rm logs the failure and co
 
 s3rm filters objects in the following order:
 
-1. `--filter-mtime-before`
-2. `--filter-mtime-after`
-3. `--filter-smaller-size`
-4. `--filter-larger-size`
-5. `--filter-include-regex`
-6. `--filter-exclude-regex`
-7. `--keep-latest-only`
-8. `FilterCallback (--filter-callback-lua-script / UserDefinedFilterCallback)`
-9. `--filter-include-content-type-regex`
-10. `--filter-exclude-content-type-regex`
-11. `--filter-include-metadata-regex`
-12. `--filter-exclude-metadata-regex`
-13. `--filter-include-tag-regex`
-14. `--filter-exclude-tag-regex`
+1. `--filter-delete-marker-only`
+2. `--filter-mtime-before`
+3. `--filter-mtime-after`
+4. `--filter-smaller-size`
+5. `--filter-larger-size`
+6. `--filter-include-regex`
+7. `--filter-exclude-regex`
+8. `--keep-latest-only`
+9. `FilterCallback (--filter-callback-lua-script / UserDefinedFilterCallback)`
+10. `--filter-include-content-type-regex`
+11. `--filter-exclude-content-type-regex`
+12. `--filter-include-metadata-regex`
+13. `--filter-exclude-metadata-regex`
+14. `--filter-include-tag-regex`
+15. `--filter-exclude-tag-regex`
 
 Filters that require additional API calls (content type, metadata, tags) are applied last to minimize unnecessary requests.
 
@@ -856,6 +869,7 @@ For more information, see `s3rm --help`.
 
 | Option | Description |
 |--------|-------------|
+| `--filter-delete-marker-only` | Delete only delete markers (requires `--delete-all-versions`) |
 | `--filter-include-regex` | Delete only objects whose key matches this regex |
 | `--filter-exclude-regex` | Skip objects whose key matches this regex |
 | `--filter-include-content-type-regex` | Delete only objects whose content type matches |
@@ -1225,12 +1239,12 @@ The E2E tests run against live AWS S3 — no mocks. Every E2E test creates a rea
 
 #### Test suite summary
 
-- **873 library unit/property tests** (including property-based tests from 15 property test files), all passing
+- **923 library unit/property tests** (including property-based tests from 16 property test files), all passing
 - **33 binary tests**, all passing
-- **125 E2E tests** against live AWS S3 across 17 test files, all passing
-- **1,031 total tests**, zero failures
-- **98.07% region coverage, 97.97% function coverage, 98.43% line coverage** (measured by `cargo llvm-cov`)
-- 15 property-based test files covering safety, versioning, optimistic locking, retry, logging, filters, Lua, rate limiting, cross-platform, library API, CI/CD, keep-latest-only, event callbacks, and additional edge cases
+- **133 E2E tests** against live AWS S3 across 18 test files, all passing
+- **1,089 total tests**, zero failures
+- **98.13% region coverage, 98.06% function coverage, 98.48% line coverage** (measured by `cargo llvm-cov`)
+- 16 property-based test files covering safety, versioning, optimistic locking, retry, logging, filters, Lua, rate limiting, cross-platform, library API, CI/CD, keep-latest-only, event callbacks, and additional edge cases
 
 #### Known limitations
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -312,14 +312,15 @@ impl DeletionPipeline {
 **Streaming Pipeline Diagram**:
 ```mermaid
 graph LR
-    List[ObjectLister] -->|Channel| F1[MtimeBeforeFilter]
+    List[ObjectLister] -->|Channel| F0[DeleteMarkerOnlyFilter]
+    F0 -->|Channel| F1[MtimeBeforeFilter]
     F1 -->|Channel| F2[MtimeAfterFilter]
     F2 -->|Channel| F3[SmallerSizeFilter]
     F3 -->|Channel| F4[LargerSizeFilter]
     F4 -->|Channel| F5[IncludeRegexFilter]
     F5 -->|Channel| F6[ExcludeRegexFilter]
-    F6 -->|Channel| F7[UserDefinedFilter]
-    F7 -->|Channel| F8[KeepLatestOnlyFilter]
+    F6 -->|Channel| F7[KeepLatestOnlyFilter]
+    F7 -->|Channel| F8[UserDefinedFilter]
     F8 -->|MPMC Channel| D1[ObjectDeleter Worker 1]
     F8 -->|MPMC Channel| D2[ObjectDeleter Worker 2]
     F8 -->|MPMC Channel| D3[ObjectDeleter Worker N]
@@ -332,14 +333,15 @@ graph LR
 1. **Check Prerequisites** (via `check_prerequisites()`): Validate configuration, handle confirmation prompt (dry-run skips confirmation but pipeline still runs fully). If `delete_all_versions` is set but the bucket is not versioned: with `--keep-latest-only`, return an error (versioning required); otherwise, silently clear the flag so the pipeline proceeds with normal deletion. Also validates that `--if-match` is not combined with `--delete-all-versions`. Called separately before `run()` so the progress bar doesn't interfere with prompts.
 2. **List Stage**: Spawn ObjectLister to list target objects into channel
 3. **Filter Stages**: Chain filter stages (each reads from previous, writes to next)
+   - DeleteMarkerOnlyFilter (if `--filter-delete-marker-only` is set; passes only delete markers, eliminates non-markers early)
    - MtimeBeforeFilter (if configured)
    - MtimeAfterFilter (if configured)
    - SmallerSizeFilter (if configured)
    - LargerSizeFilter (if configured)
    - IncludeRegexFilter (if configured)
    - ExcludeRegexFilter (if configured)
-   - UserDefinedFilter (Lua callback, if configured)
    - KeepLatestOnlyFilter (if `--keep-latest-only` is set; filters out latest versions, passes non-latest for deletion)
+   - UserDefinedFilter (Lua/Rust callback, if configured)
 4. **Delete Stage**: Spawn multiple ObjectDeleter workers (MPMC pattern)
 5. **Terminate Stage**: Consume final output and close channels
 
@@ -433,6 +435,9 @@ pub struct LargerSizeFilter  { /* ObjectFilterBase + Stage */ }
 // Regex filters for key patterns (use ObjectFilterBase internally)
 pub struct IncludeRegexFilter { /* ObjectFilterBase + Stage */ }
 pub struct ExcludeRegexFilter { /* ObjectFilterBase + Stage */ }
+
+// Delete-marker-only filter (passes only delete markers, filters out all other object types)
+pub struct DeleteMarkerOnlyFilter { /* ObjectFilterBase + Stage */ }
 
 // User-defined filter (Lua/Rust callbacks via FilterManager)
 pub struct UserDefinedFilter { /* Stage */ }
@@ -907,6 +912,7 @@ pub struct CLIArgs {
     pub delete_all_versions: bool,
     pub max_delete: Option<u64>,  // value_parser range(1..)
     pub keep_latest_only: bool,   // requires delete_all_versions; conflicts with most filters
+    pub filter_delete_marker_only: bool, // requires delete_all_versions; passes only delete markers
 
     // Filtering (same as s3sync)
     pub filter_include_regex: Option<String>,
@@ -1119,7 +1125,7 @@ s3rm s3://my-bucket/ --filter-mtime-before 2023-01-01 --worker-size 100
 
 Options are organized into clear categories matching s3sync's help structure:
 - **General**: dry-run, force, show-no-progress, delete-all-versions, max-delete, keep-latest-only
-- **Filtering**: Regex, size, time filters (identical to s3sync)
+- **Filtering**: Regex, size, time, delete-marker-only filters (identical to s3sync plus delete-marker-only)
 - **Tracing/Logging**: Verbosity, JSON, color control, AWS SDK tracing, span events
 - **AWS Configuration**: Credentials, region, endpoint (target-* only, no source-*)
 - **Performance**: Worker count, batch-size, parallel listings, rate limiting (identical to s3sync)
@@ -1404,6 +1410,7 @@ pub struct FilterConfig {
     pub larger_size: Option<u64>,
     pub smaller_size: Option<u64>,
     pub keep_latest_only: bool,
+    pub delete_marker_only: bool,
 }
 
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -2022,13 +2022,13 @@ async fn test_batch_deletion_with_partial_failure() {
 
 ### Test Coverage Goals
 
-- **Line Coverage**: >98% (current: 98.43% as of 2026-03-22, via `cargo llvm-cov report` combining lib+bin+E2E)
-- **Region Coverage**: >98% (current: 98.07%)
-- **Function Coverage**: >97% (current: 97.97%)
+- **Line Coverage**: >98% (current: 98.49% as of 2026-04-14, via `cargo llvm-cov report` combining lib+bin+E2E)
+- **Region Coverage**: >98% (current: 98.14%)
+- **Function Coverage**: >98% (current: 98.07%)
 - **Property Coverage**: 49 of 49 properties tested
 - **Critical Path Coverage**: 100% (deletion logic, safety checks, error handling)
 
-**Note**: Coverage includes unit tests and E2E tests (125 tests across 17 test files). The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
+**Note**: Coverage includes unit tests and E2E tests across 18 test files. The remaining uncovered code is primarily in runtime paths that require live AWS infrastructure (S3 API calls, network error handlers).
 
 ### Continuous Integration
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -251,3 +251,16 @@ s3rm-rs is architected as a library-first design, where all core functionality i
 10. WHERE --keep-latest-only is used with --dry-run, THE S3rm_Tool SHALL report simulated deletion statistics without actually deleting any versions
 11. WHERE --keep-latest-only is used with --max-delete, THE S3rm_Tool SHALL stop deleting after the specified limit is reached
 12. THE --keep-latest-only feature SHALL operate correctly when distributed across multiple concurrent workers
+
+### Requirement 15: Delete Marker Only Filtering
+
+**User Story:** As a user managing versioned S3 buckets, I want to delete only delete markers so that I can clean up stale delete markers without affecting actual object versions.
+
+#### Acceptance Criteria
+
+1. WHERE the --filter-delete-marker-only flag is provided, THE S3rm_Tool SHALL delete only objects that are delete markers (S3Object::DeleteMarker variant), filtering out all versioned objects and non-versioned objects
+2. THE --filter-delete-marker-only flag SHALL require --delete-all-versions to be specified (enforced at CLI parse time)
+3. THE DeleteMarkerOnlyFilter SHALL be inserted as the FIRST filter in the pipeline (before MtimeBeforeFilter), to eliminate non-marker objects early and reduce work for downstream filters
+4. THE DeleteMarkerOnlyFilter SHALL pass both latest and non-latest delete markers
+5. WHERE --filter-delete-marker-only is used with other filters, THE S3rm_Tool SHALL apply delete-marker-only filtering first, then apply remaining filters to the surviving delete markers
+6. WHERE --filter-delete-marker-only is used with --dry-run, THE S3rm_Tool SHALL report simulated deletion statistics without actually deleting any delete markers

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -12,7 +12,7 @@
 │   ├── terminator.rs       # Terminator stage
 │   ├── config/             # Configuration and argument parsing
 │   ├── storage/            # Storage trait and S3 implementation
-│   ├── filters/            # Filter stages (regex, size, time, keep-latest-only, Lua)
+│   ├── filters/            # Filter stages (regex, size, time, delete-marker-only, keep-latest-only, Lua)
 │   ├── deleter/            # Deletion components (batch, single, worker)
 │   ├── callback/           # Callback managers (event, filter)
 │   ├── safety/             # Safety features (confirmation, dry-run)
@@ -35,21 +35,28 @@
 │   ├── event.lua           # Example Lua event callback script
 │   └── library_usage.rs    # Example Rust library usage
 ├── test_data/              # Test data files
-│   └── test_config/        # Mock AWS config/credentials for testing
+│   ├── test_config/        # Mock AWS config/credentials for testing
+│   └── test_config_creds_in_config/ # Mock AWS config with credentials in config file
 ├── docs/                   # Permanent documentation (requirements, design, product, tech, structure, e2e_test_cases)
 ├── steering/
-│   └── init_build/         # Active build phase (tasks, phase README)
+│   ├── init_build/         # Initial build phase (tasks, phase README, e2e test plan)
+│   ├── v1.0.1/             # v1.0.1 release phase
+│   ├── v1.0.2/             # v1.0.2 release phase
+│   ├── v1.1.0/             # v1.1.0 release phase
+│   └── v1.1.1/             # v1.1.1 release phase
 ├── tests/                  # E2E integration tests (gated behind #[cfg(e2e_test)], require AWS credentials with s3rm-e2e-test profile)
 │   ├── common/
 │   │   └── mod.rs          # Shared E2E test infrastructure (TestHelper, BucketGuard, etc.)
 │   ├── e2e_aws_config.rs   # AWS configuration tests (4 tests)
 │   ├── e2e_callback.rs     # Callback tests - Lua and Rust (7 tests)
 │   ├── e2e_combined.rs     # Combined feature tests (7 tests)
+│   ├── e2e_delete_marker_only.rs # Delete-marker-only filter tests
 │   ├── e2e_deletion.rs     # Deletion mode tests (7 tests)
 │   ├── e2e_error.rs        # Error handling and exit code tests (7 tests)
 │   ├── e2e_express_one_zone.rs # Express One Zone directory bucket tests (3 tests)
 │   ├── e2e_filter.rs       # Filter tests - regex, size, time, etc. (24 tests)
 │   ├── e2e_keep_latest_only.rs # Keep-latest-only version retention tests (15 tests)
+│   ├── e2e_listing.rs      # Object listing tests
 │   ├── e2e_optimistic.rs   # Optimistic locking / If-Match tests (4 tests)
 │   ├── e2e_performance.rs  # Performance configuration tests (5 tests)
 │   ├── e2e_retry.rs        # Retry and timeout tests (3 tests)
@@ -94,6 +101,7 @@ src/
 ├── lister.rs               # ObjectLister (reused from s3sync) + Property 5 tests
 ├── filters/
 │   ├── mod.rs              # ObjectFilter trait, ObjectFilterBase
+│   ├── delete_marker_only.rs # DeleteMarkerOnlyFilter (passes only delete markers)
 │   ├── mtime_before.rs     # MtimeBeforeFilter
 │   ├── mtime_after.rs      # MtimeAfterFilter
 │   ├── smaller_size.rs     # SmallerSizeFilter
@@ -129,6 +137,7 @@ src/
 │   └── token.rs            # PipelineCancellationToken type alias
 ├── property_tests/          # Root-level property-based tests (consolidated)
 │   ├── mod.rs               # Module declarations
+│   ├── access_key_masking_properties.rs # Access key masking tests
 │   ├── lib_properties.rs    # Library API (Properties 44-47)
 │   ├── versioning_properties.rs  # Versioning (Properties 25-28)
 │   ├── retry_properties.rs       # Retry/error handling (Properties 29-30)
@@ -182,8 +191,8 @@ src/
 
 Tests are co-located with source code or collected under `tests/`:
 - Unit tests in `#[cfg(test)]` modules within each source file
-- Property-based tests in `src/property_tests/` (15 files); `indicator_properties.rs` in `bin/s3rm/`
+- Property-based tests in `src/property_tests/` (16 files); `indicator_properties.rs` in `bin/s3rm/`
 - E2E integration tests in `tests/e2e_*.rs` files, each gated behind `#[cfg(e2e_test)]`
   - Require live AWS credentials configured under the `s3rm-e2e-test` AWS profile
   - Shared helpers (bucket setup/teardown, object seeding, assertion utilities) live in `tests/common/mod.rs`
-  - 109 test cases total across 16 test files covering deletion, filtering, versioning, safety, callbacks, tracing, retry, optimistic locking, performance, statistics, error handling, AWS config, Express One Zone, keep-latest-only, combined, and stress scenarios
+  - 18 test files covering deletion, filtering, versioning, safety, callbacks, tracing, retry, optimistic locking, performance, statistics, error handling, AWS config, Express One Zone, keep-latest-only, delete-marker-only, listing, combined, and stress scenarios

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -12,7 +12,7 @@
 - Clap (CLI argument parsing)
 - Tracing (structured logging)
 - mlua (Lua VM integration for callbacks)
-- Regex (pattern matching for filters)
+- fancy-regex (pattern matching for filters)
 - Indicatif (progress bars)
 
 ## Architecture Pattern

--- a/src/bin/s3rm/main.rs
+++ b/src/bin/s3rm/main.rs
@@ -108,15 +108,16 @@ async fn run(mut config: Config) -> Result<()> {
     {
         let cancellation_token = create_pipeline_cancellation_token();
 
-        ctrl_c_handler::spawn_ctrl_c_handler(cancellation_token.clone());
-
         let start_time = tokio::time::Instant::now();
         debug!("deletion pipeline start.");
 
-        let mut pipeline = DeletionPipeline::new(config.clone(), cancellation_token).await;
+        let mut pipeline = DeletionPipeline::new(config.clone(), cancellation_token.clone()).await;
 
         // Check prerequisites (confirmation prompt) before starting the indicator,
         // so the progress bar doesn't interfere with the prompt.
+        // The Ctrl+C handler is spawned AFTER this so that the default OS
+        // SIGINT handler remains active during the blocking stdin read,
+        // allowing Ctrl+C to terminate the process immediately at the prompt.
         if let Err(e) = pipeline.check_prerequisites().await {
             pipeline.close_stats_sender();
             if is_cancelled_error(&e) {
@@ -128,6 +129,10 @@ async fn run(mut config: Config) -> Result<()> {
             error!("{}", e);
             std::process::exit(code);
         }
+
+        // Now that the blocking prompt is done, install the async Ctrl+C
+        // handler for graceful pipeline shutdown.
+        ctrl_c_handler::spawn_ctrl_c_handler(cancellation_token);
 
         let indicator_join_handle = indicator::show_indicator(
             pipeline.get_stats_receiver(),

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -166,6 +166,16 @@ pub struct CLIArgs {
     )]
     pub keep_latest_only: bool,
 
+    /// Delete only delete markers (requires --delete-all-versions)
+    #[arg(
+        long,
+        env,
+        default_value_t = false,
+        requires = "delete_all_versions",
+        help_heading = "Filtering"
+    )]
+    pub filter_delete_marker_only: bool,
+
     // -----------------------------------------------------------------------
     // Filter options (same as s3sync)
     // -----------------------------------------------------------------------
@@ -589,6 +599,7 @@ impl CLIArgs {
             larger_size,
             smaller_size,
             keep_latest_only: self.keep_latest_only,
+            delete_marker_only: self.filter_delete_marker_only,
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -269,6 +269,7 @@ pub struct FilterConfig {
     pub larger_size: Option<u64>,
     pub smaller_size: Option<u64>,
     pub keep_latest_only: bool,
+    pub delete_marker_only: bool,
 }
 
 #[cfg(test)]

--- a/src/filters/delete_marker_only.rs
+++ b/src/filters/delete_marker_only.rs
@@ -1,0 +1,455 @@
+//! Delete-marker-only filter stage.
+//!
+//! Passes only objects that are delete markers (`S3Object::DeleteMarker`).
+//! All other object types (versioned objects, non-versioned objects) are filtered out.
+//! This filter is off by default and activated via `--filter-delete-marker-only`.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::debug;
+
+use crate::config::FilterConfig;
+use crate::filters::{ObjectFilter, ObjectFilterBase};
+use crate::stage::Stage;
+use crate::types::S3Object;
+
+pub struct DeleteMarkerOnlyFilter<'a> {
+    base: ObjectFilterBase<'a>,
+}
+
+const FILTER_NAME: &str = "DeleteMarkerOnlyFilter";
+
+impl DeleteMarkerOnlyFilter<'_> {
+    pub fn new(base: Stage) -> Self {
+        Self {
+            base: ObjectFilterBase {
+                base,
+                name: FILTER_NAME,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl ObjectFilter for DeleteMarkerOnlyFilter<'_> {
+    async fn filter(&self) -> Result<()> {
+        self.base.filter(is_delete_marker).await
+    }
+}
+
+fn is_delete_marker(object: &S3Object, _config: &FilterConfig) -> bool {
+    if !object.is_delete_marker() {
+        debug!(
+            name = FILTER_NAME,
+            key = object.key(),
+            version_id = object.version_id(),
+            "object filtered (not a delete marker)."
+        );
+
+        return false;
+    }
+
+    true
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use crate::config::FilterConfig;
+    use crate::filters::tests::create_base_helper;
+    use crate::test_utils::init_dummy_tracing_subscriber;
+    use crate::types::token;
+    use aws_sdk_s3::types::{DeleteMarkerEntry, Object, ObjectVersion};
+
+    // --- Predicate unit tests ---
+
+    #[test]
+    fn latest_delete_marker_passes_through() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("test-key")
+                .version_id("dm1")
+                .is_latest(true)
+                .build(),
+        );
+        assert!(is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn non_latest_delete_marker_passes_through() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("test-key")
+                .version_id("dm2")
+                .is_latest(false)
+                .build(),
+        );
+        assert!(is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn delete_marker_with_none_is_latest_passes_through() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        // is_latest omitted (None) — still a delete marker, must pass.
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("test-key")
+                .version_id("dm-none")
+                .build(),
+        );
+        assert!(is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn delete_marker_without_version_id_passes_through() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig::default();
+
+        // Minimal delete marker — no version_id set.
+        let object = S3Object::DeleteMarker(DeleteMarkerEntry::builder().key("test-key").build());
+        assert!(is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn delete_marker_with_empty_key_passes_through() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig::default();
+
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("")
+                .version_id("dm-empty")
+                .build(),
+        );
+        assert!(is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn latest_versioned_object_is_filtered_out() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        let object = S3Object::Versioning(
+            ObjectVersion::builder()
+                .key("test-key")
+                .version_id("v1")
+                .is_latest(true)
+                .build(),
+        );
+        assert!(!is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn non_latest_versioned_object_is_filtered_out() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        let object = S3Object::Versioning(
+            ObjectVersion::builder()
+                .key("test-key")
+                .version_id("v2")
+                .is_latest(false)
+                .build(),
+        );
+        assert!(!is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn versioned_object_with_none_is_latest_is_filtered_out() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig::default();
+
+        let object = S3Object::Versioning(
+            ObjectVersion::builder()
+                .key("test-key")
+                .version_id("v-none")
+                .build(),
+        );
+        assert!(!is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn non_versioned_object_is_filtered_out() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig {
+            delete_marker_only: true,
+            ..Default::default()
+        };
+
+        let object = S3Object::NotVersioning(Object::builder().key("test-key").build());
+        assert!(!is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn non_versioned_object_with_size_is_filtered_out() {
+        init_dummy_tracing_subscriber();
+
+        let config = FilterConfig::default();
+
+        let object = S3Object::NotVersioning(Object::builder().key("test-key").size(1024).build());
+        assert!(!is_delete_marker(&object, &config));
+    }
+
+    #[test]
+    fn filter_ignores_config_fields() {
+        init_dummy_tracing_subscriber();
+
+        // Filter decision depends only on S3Object variant, not config values.
+        let config_with_extras = FilterConfig {
+            delete_marker_only: false, // even when false, predicate still works
+            keep_latest_only: true,
+            larger_size: Some(999),
+            ..Default::default()
+        };
+
+        let marker = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("k")
+                .version_id("dm")
+                .build(),
+        );
+        assert!(is_delete_marker(&marker, &config_with_extras));
+
+        let version =
+            S3Object::Versioning(ObjectVersion::builder().key("k").version_id("v").build());
+        assert!(!is_delete_marker(&version, &config_with_extras));
+    }
+
+    // --- Integration tests (full filter stage with async channels) ---
+
+    #[tokio::test]
+    async fn stage_passes_delete_marker_to_next_stage() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("passed-marker")
+                .version_id("dm1")
+                .is_latest(true)
+                .build(),
+        );
+        sender.send(object).await.unwrap();
+        sender.close();
+
+        filter.filter().await.unwrap();
+
+        let received = next_stage_receiver.recv().await.unwrap();
+        assert_eq!(received.key(), "passed-marker");
+    }
+
+    #[tokio::test]
+    async fn stage_filters_out_versioned_object() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        let object = S3Object::Versioning(
+            ObjectVersion::builder()
+                .key("blocked-version")
+                .version_id("v1")
+                .is_latest(true)
+                .build(),
+        );
+        sender.send(object).await.unwrap();
+        sender.close();
+
+        filter.filter().await.unwrap();
+
+        assert!(next_stage_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stage_filters_out_non_versioned_object() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        let object =
+            S3Object::NotVersioning(Object::builder().key("blocked-object").size(512).build());
+        sender.send(object).await.unwrap();
+        sender.close();
+
+        filter.filter().await.unwrap();
+
+        assert!(next_stage_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stage_mixed_objects_only_delete_markers_pass() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        // Send a mix of object types
+        let objects: Vec<S3Object> = vec![
+            S3Object::DeleteMarker(
+                DeleteMarkerEntry::builder()
+                    .key("marker-1")
+                    .version_id("dm1")
+                    .is_latest(true)
+                    .build(),
+            ),
+            S3Object::Versioning(
+                ObjectVersion::builder()
+                    .key("version-1")
+                    .version_id("v1")
+                    .is_latest(true)
+                    .build(),
+            ),
+            S3Object::NotVersioning(Object::builder().key("object-1").size(100).build()),
+            S3Object::DeleteMarker(
+                DeleteMarkerEntry::builder()
+                    .key("marker-2")
+                    .version_id("dm2")
+                    .is_latest(false)
+                    .build(),
+            ),
+            S3Object::Versioning(
+                ObjectVersion::builder()
+                    .key("version-2")
+                    .version_id("v2")
+                    .is_latest(false)
+                    .build(),
+            ),
+        ];
+
+        for obj in objects {
+            sender.send(obj).await.unwrap();
+        }
+        sender.close();
+
+        filter.filter().await.unwrap();
+
+        // Only the two delete markers should pass through
+        let first = next_stage_receiver.recv().await.unwrap();
+        assert_eq!(first.key(), "marker-1");
+
+        let second = next_stage_receiver.recv().await.unwrap();
+        assert_eq!(second.key(), "marker-2");
+
+        assert!(next_stage_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stage_completes_when_cancelled() {
+        init_dummy_tracing_subscriber();
+
+        let (_sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        cancellation_token.cancel();
+        filter.filter().await.unwrap();
+
+        assert!(next_stage_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn stage_completes_when_output_channel_closed() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        // Close the output channel before sending
+        next_stage_receiver.close();
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        let object = S3Object::DeleteMarker(
+            DeleteMarkerEntry::builder()
+                .key("marker")
+                .version_id("dm1")
+                .build(),
+        );
+        sender.send(object).await.unwrap();
+
+        // Should not hang or panic — graceful shutdown
+        filter.filter().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn stage_empty_input_completes_immediately() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+        base.config.filter_config.delete_marker_only = true;
+
+        let filter = DeleteMarkerOnlyFilter::new(base);
+
+        // Close input immediately — no objects
+        sender.close();
+
+        filter.filter().await.unwrap();
+
+        assert!(next_stage_receiver.try_recv().is_err());
+    }
+}

--- a/src/filters/mod.rs
+++ b/src/filters/mod.rs
@@ -23,6 +23,7 @@ use crate::stage::{SendResult, Stage};
 use crate::types::event_callback::{EventData, EventType};
 use crate::types::{DeletionStatistics, S3Object};
 
+pub mod delete_marker_only;
 pub mod exclude_regex;
 pub mod include_regex;
 pub mod keep_latest_only;
@@ -32,6 +33,7 @@ pub mod mtime_before;
 pub mod smaller_size;
 pub mod user_defined;
 
+pub use delete_marker_only::DeleteMarkerOnlyFilter;
 pub use exclude_regex::ExcludeRegexFilter;
 pub use include_regex::IncludeRegexFilter;
 pub use keep_latest_only::KeepLatestOnlyFilter;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -20,8 +20,8 @@ use crate::config::Config;
 use crate::deleter::ObjectDeleter;
 use crate::filters::user_defined::UserDefinedFilter;
 use crate::filters::{
-    ExcludeRegexFilter, IncludeRegexFilter, KeepLatestOnlyFilter, LargerSizeFilter,
-    MtimeAfterFilter, MtimeBeforeFilter, ObjectFilter, SmallerSizeFilter,
+    DeleteMarkerOnlyFilter, ExcludeRegexFilter, IncludeRegexFilter, KeepLatestOnlyFilter,
+    LargerSizeFilter, MtimeAfterFilter, MtimeBeforeFilter, ObjectFilter, SmallerSizeFilter,
 };
 use crate::lister::ObjectLister;
 use crate::safety::SafetyChecker;
@@ -482,13 +482,25 @@ impl DeletionPipeline {
     /// configuration is set. Filters are chained in this order:
     /// 1. MtimeBeforeFilter
     /// 2. MtimeAfterFilter
-    /// 3. SmallerSizeFilter
-    /// 4. LargerSizeFilter
-    /// 5. IncludeRegexFilter
-    /// 6. ExcludeRegexFilter
-    /// 7. UserDefinedFilter (Lua/Rust callback)
+    /// 1. DeleteMarkerOnlyFilter
+    /// 2. MtimeBeforeFilter
+    /// 3. MtimeAfterFilter
+    /// 4. SmallerSizeFilter
+    /// 5. LargerSizeFilter
+    /// 6. IncludeRegexFilter
+    /// 7. ExcludeRegexFilter
+    /// 8. KeepLatestOnlyFilter
+    /// 9. UserDefinedFilter (Lua/Rust callback)
     fn filter_objects(&self, objects_list: Receiver<S3Object>) -> Receiver<S3Object> {
         let mut previous_stage_receiver = objects_list;
+
+        // DeleteMarkerOnlyFilter (first — eliminates non-markers early)
+        if self.config.filter_config.delete_marker_only {
+            let (stage, new_receiver) =
+                self.create_spsc_stage(Some(previous_stage_receiver), self.has_warning.clone());
+            self.spawn_filter(Box::new(DeleteMarkerOnlyFilter::new(stage)));
+            previous_stage_receiver = new_receiver;
+        }
 
         // MtimeBeforeFilter
         if self.config.filter_config.before_time.is_some() {

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -241,6 +241,15 @@ impl DeletionPipeline {
             ));
         }
 
+        // --filter-delete-marker-only requires --delete-all-versions. The CLI
+        // enforces this via clap's `requires`, but the library API can construct
+        // Config directly, so validate at runtime to prevent a silent no-op.
+        if self.config.filter_config.delete_marker_only && !self.config.delete_all_versions {
+            return Err(anyhow::anyhow!(
+                "--filter-delete-marker-only requires --delete-all-versions."
+            ));
+        }
+
         // --if-match is incompatible with --delete-all-versions. S3 does not
         // support If-Match conditional headers when deleting by version_id
         // (returns NotImplemented). The CLI enforces this via clap's
@@ -259,11 +268,19 @@ impl DeletionPipeline {
         if self.config.delete_all_versions {
             let versioning_enabled = self.target.is_versioning_enabled().await?;
             if !versioning_enabled {
-                // --keep-latest-only requires a versioned bucket; error out.
+                // --keep-latest-only cannot be used on a non-versioned bucket.
                 if self.config.filter_config.keep_latest_only {
                     return Err(anyhow::anyhow!(
-                        "--keep-latest-only requires a versioning-enabled bucket, \
-                         but the target bucket does not have versioning enabled."
+                        "--keep-latest-only cannot be used on a non-versioned bucket."
+                    ));
+                }
+                // --filter-delete-marker-only cannot be used on a non-versioned
+                // bucket. Error out rather than silently clearing
+                // delete_all_versions, which would turn this into a confusing
+                // no-op.
+                if self.config.filter_config.delete_marker_only {
+                    return Err(anyhow::anyhow!(
+                        "--filter-delete-marker-only cannot be used on a non-versioned bucket."
                     ));
                 }
                 self.config.delete_all_versions = false;
@@ -1635,6 +1652,93 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("--if-match cannot be used with --delete-all-versions")
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_delete_marker_only_without_delete_all_versions_errors() {
+        init_dummy_tracing_subscriber();
+
+        let (stats_sender, stats_receiver) = async_channel::unbounded();
+        let has_warning = Arc::new(AtomicBool::new(false));
+        let storage: Storage = Box::new(ListingMockStorage {
+            objects: vec![],
+            stats_sender,
+            has_warning: has_warning.clone(),
+        });
+
+        let mut config = create_test_config();
+        config.force = true;
+        config.filter_config.delete_marker_only = true;
+        config.delete_all_versions = false;
+        let cancellation_token = create_pipeline_cancellation_token();
+
+        let mut pipeline = DeletionPipeline {
+            config,
+            target: storage,
+            cancellation_token,
+            stats_receiver,
+            has_error: Arc::new(AtomicBool::new(false)),
+            has_panic: Arc::new(AtomicBool::new(false)),
+            has_warning,
+            errors: Arc::new(Mutex::new(VecDeque::new())),
+            ready: true,
+            prerequisites_checked: false,
+            deletion_stats_report: Arc::new(DeletionStatsReport::new()),
+        };
+
+        // Should error: delete_marker_only requires delete_all_versions
+        let result = pipeline.check_prerequisites().await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("--filter-delete-marker-only requires --delete-all-versions")
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_delete_marker_only_on_non_versioned_bucket_errors() {
+        init_dummy_tracing_subscriber();
+
+        let (stats_sender, stats_receiver) = async_channel::unbounded();
+        let has_warning = Arc::new(AtomicBool::new(false));
+        // ListingMockStorage.is_versioning_enabled() returns false
+        let storage: Storage = Box::new(ListingMockStorage {
+            objects: vec![],
+            stats_sender,
+            has_warning: has_warning.clone(),
+        });
+
+        let mut config = create_test_config();
+        config.force = true;
+        config.filter_config.delete_marker_only = true;
+        config.delete_all_versions = true;
+        let cancellation_token = create_pipeline_cancellation_token();
+
+        let mut pipeline = DeletionPipeline {
+            config,
+            target: storage,
+            cancellation_token,
+            stats_receiver,
+            has_error: Arc::new(AtomicBool::new(false)),
+            has_panic: Arc::new(AtomicBool::new(false)),
+            has_warning,
+            errors: Arc::new(Mutex::new(VecDeque::new())),
+            ready: true,
+            prerequisites_checked: false,
+            deletion_stats_report: Arc::new(DeletionStatsReport::new()),
+        };
+
+        // Should error: non-versioned bucket + delete_marker_only
+        let result = pipeline.check_prerequisites().await;
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("--filter-delete-marker-only cannot be used on a non-versioned bucket")
         );
     }
 

--- a/src/property_tests/access_key_masking_properties.rs
+++ b/src/property_tests/access_key_masking_properties.rs
@@ -1,0 +1,177 @@
+// Property-based tests for access key masking.
+//
+// Feature: s3rm-rs, Property: Access Key Masking
+// For any access key string, the masking function must preserve the output
+// length, show only the first 4 and last 4 characters for keys of 9+ chars,
+// fully mask shorter keys, and never leak the original middle portion.
+// **Validates: Requirements 4.10 (credential security in logs)**
+
+#[cfg(test)]
+mod tests {
+    use crate::types::AccessKeys;
+    use crate::types::mask_access_key;
+    use proptest::prelude::*;
+
+    // -----------------------------------------------------------------------
+    // Generators
+    // -----------------------------------------------------------------------
+
+    /// Generate a random access key string with ASCII alphanumeric characters.
+    fn arb_access_key() -> impl Strategy<Value = String> {
+        "[A-Za-z0-9/+]{0,64}"
+    }
+
+    /// Generate a realistic AWS access key ID (20 chars, starts with AKIA).
+    fn arb_aws_access_key_id() -> impl Strategy<Value = String> {
+        "[A-Z0-9]{16}".prop_map(|suffix| format!("AKIA{suffix}"))
+    }
+
+    // -----------------------------------------------------------------------
+    // Properties
+    // -----------------------------------------------------------------------
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(500))]
+
+        /// Masked output must always have the same length as the input.
+        #[test]
+        fn prop_mask_preserves_length(key in arb_access_key()) {
+            let masked = mask_access_key(&key);
+            prop_assert_eq!(
+                masked.len(),
+                key.len(),
+                "Masked length must equal input length for key of {} chars",
+                key.len()
+            );
+        }
+
+        /// Keys shorter than 9 characters must be fully masked with asterisks.
+        #[test]
+        fn prop_short_keys_fully_masked(key in "[A-Za-z0-9]{0,8}") {
+            let masked = mask_access_key(&key);
+            prop_assert!(
+                masked.chars().all(|c| c == '*'),
+                "Short key ({} chars) must be fully masked, got: {}",
+                key.len(),
+                masked
+            );
+        }
+
+        /// Keys of 9+ characters must show exactly the first 4 and last 4
+        /// characters from the original, with asterisks in between.
+        #[test]
+        fn prop_long_keys_show_prefix_and_suffix(key in "[A-Za-z0-9]{9,64}") {
+            let masked = mask_access_key(&key);
+
+            // First 4 characters preserved
+            prop_assert_eq!(
+                &masked[..4],
+                &key[..4],
+                "First 4 chars must be preserved"
+            );
+            // Last 4 characters preserved
+            prop_assert_eq!(
+                &masked[masked.len() - 4..],
+                &key[key.len() - 4..],
+                "Last 4 chars must be preserved"
+            );
+        }
+
+        /// The middle portion of long keys must be all asterisks.
+        #[test]
+        fn prop_long_keys_middle_all_asterisks(key in "[A-Za-z0-9]{9,64}") {
+            let masked = mask_access_key(&key);
+            let middle = &masked[4..masked.len() - 4];
+            prop_assert!(
+                middle.chars().all(|c| c == '*'),
+                "Middle portion must be all asterisks, got: {}",
+                middle
+            );
+        }
+
+        /// The middle portion of the original key must never appear in the
+        /// masked output (for keys long enough to have a non-trivial middle).
+        #[test]
+        fn prop_original_middle_not_leaked(key in "[A-Za-z0-9]{10,64}") {
+            let masked = mask_access_key(&key);
+            let original_middle = &key[4..key.len() - 4];
+            // Only check if middle is non-empty and not all the same char
+            // (e.g., "AAAA" middle could appear in prefix/suffix by coincidence)
+            if original_middle.len() > 1 {
+                prop_assert!(
+                    !masked.contains(original_middle),
+                    "Masked output must not contain the original middle: {}",
+                    original_middle
+                );
+            }
+        }
+
+        /// Realistic AWS access key IDs (AKIA..., 20 chars) must be properly
+        /// masked with first 4 and last 4 visible.
+        #[test]
+        fn prop_aws_key_id_masked_correctly(key in arb_aws_access_key_id()) {
+            let masked = mask_access_key(&key);
+            prop_assert_eq!(masked.len(), 20);
+            prop_assert!(masked.starts_with("AKIA"));
+            prop_assert_eq!(&masked[masked.len() - 4..], &key[key.len() - 4..]);
+
+            let middle = &masked[4..16];
+            prop_assert!(
+                middle.chars().all(|c| c == '*'),
+                "Middle 12 chars must be asterisks for AWS key, got: {}",
+                middle
+            );
+        }
+
+        /// The Debug impl of AccessKeys must never contain the full access key.
+        #[test]
+        fn prop_debug_never_leaks_full_access_key(key in "[A-Za-z0-9]{9,40}") {
+            let access_keys = AccessKeys {
+                access_key: key.clone(),
+                secret_access_key: "secret".to_string(),
+                session_token: None,
+            };
+            let debug_string = format!("{access_keys:?}");
+            prop_assert!(
+                !debug_string.contains(&key),
+                "Debug output must not contain the full access key"
+            );
+        }
+
+        /// The Debug impl of AccessKeys must never contain the secret access key.
+        #[test]
+        fn prop_debug_never_leaks_secret_key(
+            key in "[A-Za-z0-9]{9,40}",
+            secret in "[A-Za-z0-9/+]{20,60}",
+        ) {
+            let access_keys = AccessKeys {
+                access_key: key,
+                secret_access_key: secret.clone(),
+                session_token: None,
+            };
+            let debug_string = format!("{access_keys:?}");
+            prop_assert!(
+                !debug_string.contains(&secret),
+                "Debug output must not contain the secret access key"
+            );
+        }
+
+        /// The Debug impl of AccessKeys must never contain the session token.
+        #[test]
+        fn prop_debug_never_leaks_session_token(
+            key in "[A-Za-z0-9]{9,40}",
+            token in "[A-Za-z0-9/+]{20,60}",
+        ) {
+            let access_keys = AccessKeys {
+                access_key: key,
+                secret_access_key: "secret".to_string(),
+                session_token: Some(token.clone()),
+            };
+            let debug_string = format!("{access_keys:?}");
+            prop_assert!(
+                !debug_string.contains(&token),
+                "Debug output must not contain the session token"
+            );
+        }
+    }
+}

--- a/src/property_tests/mod.rs
+++ b/src/property_tests/mod.rs
@@ -6,6 +6,7 @@
 //! Note: `indicator_properties` remains in `bin/s3rm/` because it belongs
 //! to the binary crate and imports binary-local modules.
 
+mod access_key_masking_properties;
 mod additional_properties;
 mod aws_config_properties;
 mod cicd_properties;

--- a/src/storage/s3/client_builder.rs
+++ b/src/storage/s3/client_builder.rs
@@ -61,15 +61,22 @@ impl ClientConfig {
             crate::types::S3Credentials::Profile(profile_name) => {
                 let mut builder = aws_config::profile::ProfileFileCredentialsProvider::builder();
 
-                if let Some(aws_shared_credentials_file) = self
+                let aws_config_file = self.client_config_location.aws_config_file.as_ref();
+                let aws_credentials_file = self
                     .client_config_location
                     .aws_shared_credentials_file
-                    .as_ref()
-                {
-                    let profile_files = EnvConfigFiles::builder()
-                        .with_file(EnvConfigFileKind::Credentials, aws_shared_credentials_file)
-                        .build();
-                    builder = builder.profile_files(profile_files)
+                    .as_ref();
+
+                if aws_config_file.is_some() || aws_credentials_file.is_some() {
+                    let mut files_builder = EnvConfigFiles::builder();
+                    if let Some(path) = aws_config_file {
+                        files_builder = files_builder.with_file(EnvConfigFileKind::Config, path);
+                    }
+                    if let Some(path) = aws_credentials_file {
+                        files_builder =
+                            files_builder.with_file(EnvConfigFileKind::Credentials, path);
+                    }
+                    builder = builder.profile_files(files_builder.build());
                 }
 
                 config_loader =
@@ -84,11 +91,21 @@ impl ClientConfig {
         let mut builder = aws_config::profile::ProfileFileRegionProvider::builder();
 
         if let crate::types::S3Credentials::Profile(profile_name) = &self.credential {
-            if let Some(aws_config_file) = self.client_config_location.aws_config_file.as_ref() {
-                let profile_files = EnvConfigFiles::builder()
-                    .with_file(EnvConfigFileKind::Config, aws_config_file)
-                    .build();
-                builder = builder.profile_files(profile_files);
+            let aws_config_file = self.client_config_location.aws_config_file.as_ref();
+            let aws_credentials_file = self
+                .client_config_location
+                .aws_shared_credentials_file
+                .as_ref();
+
+            if aws_config_file.is_some() || aws_credentials_file.is_some() {
+                let mut files_builder = EnvConfigFiles::builder();
+                if let Some(path) = aws_config_file {
+                    files_builder = files_builder.with_file(EnvConfigFileKind::Config, path);
+                }
+                if let Some(path) = aws_credentials_file {
+                    files_builder = files_builder.with_file(EnvConfigFileKind::Credentials, path);
+                }
+                builder = builder.profile_files(files_builder.build());
             }
             builder = builder.profile_name(profile_name)
         }
@@ -176,6 +193,7 @@ mod tests {
     use super::*;
     use crate::test_utils::init_dummy_tracing_subscriber;
     use crate::types::{AccessKeys, ClientConfigLocation};
+    use aws_sdk_s3::config::ProvideCredentials;
     use aws_smithy_types::checksum_config::RequestChecksumCalculation;
 
     #[tokio::test]
@@ -577,6 +595,239 @@ mod tests {
         assert!(timeout_config.connect_timeout().is_some());
         assert!(timeout_config.read_timeout().is_none());
         assert!(timeout_config.has_timeouts());
+    }
+
+    // ===================================================================
+    // Profile file wiring tests — verify that both aws_config_file and
+    // aws_shared_credentials_file are passed to both the credentials
+    // provider and the region provider.
+    // ===================================================================
+
+    /// Helper: build a profile-based ClientConfig with the given file paths.
+    fn profile_client_config(
+        aws_config_file: Option<&str>,
+        aws_shared_credentials_file: Option<&str>,
+        profile_name: &str,
+        region: Option<&str>,
+    ) -> ClientConfig {
+        ClientConfig {
+            client_config_location: ClientConfigLocation {
+                aws_config_file: aws_config_file.map(Into::into),
+                aws_shared_credentials_file: aws_shared_credentials_file.map(Into::into),
+            },
+            credential: crate::types::S3Credentials::Profile(profile_name.to_string()),
+            region: region.map(|r| r.to_string()),
+            endpoint_url: Some("https://localhost".to_string()),
+            force_path_style: false,
+            retry_config: crate::config::RetryConfig {
+                aws_max_attempts: 1,
+                initial_backoff_milliseconds: 100,
+            },
+            cli_timeout_config: crate::config::CLITimeoutConfig {
+                operation_timeout_milliseconds: None,
+                operation_attempt_timeout_milliseconds: None,
+                connect_timeout_milliseconds: None,
+                read_timeout_milliseconds: None,
+            },
+            disable_stalled_stream_protection: false,
+            request_checksum_calculation: RequestChecksumCalculation::WhenRequired,
+            accelerate: false,
+            request_payer: None,
+        }
+    }
+
+    /// Both files provided — credentials resolve from credentials file.
+    #[tokio::test]
+    async fn profile_credentials_resolved_with_both_files() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config/config"),
+            Some("./test_data/test_config/credentials"),
+            "aws",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+        let provider = sdk_config.credentials_provider().unwrap();
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "my_aws_profile_access_key");
+        assert_eq!(
+            creds.secret_access_key(),
+            "my_aws_profile_secret_access_key"
+        );
+        assert_eq!(creds.session_token(), Some("my_aws_profile_session_token"));
+    }
+
+    /// Both files provided — region resolves from config file.
+    #[tokio::test]
+    async fn profile_region_resolved_with_both_files() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config/config"),
+            Some("./test_data/test_config/credentials"),
+            "aws",
+            None, // no CLI override — should fall back to config file
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+
+        assert_eq!(sdk_config.region().unwrap().to_string(), "ap-northeast-1");
+    }
+
+    /// Only credentials file — credentials resolve, region uses CLI value.
+    #[tokio::test]
+    async fn profile_credentials_resolved_with_credentials_file_only() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            None,
+            Some("./test_data/test_config/credentials"),
+            "aws",
+            Some("us-east-1"),
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+        let provider = sdk_config.credentials_provider().unwrap();
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "my_aws_profile_access_key");
+        assert_eq!(
+            creds.secret_access_key(),
+            "my_aws_profile_secret_access_key"
+        );
+
+        assert_eq!(sdk_config.region().unwrap().to_string(), "us-east-1");
+    }
+
+    /// Only config file — credentials defined in the config file are resolved.
+    /// This is the primary scenario for the aws_config_file fix: profiles
+    /// can define credentials in ~/.aws/config (e.g. for SSO, source_profile,
+    /// or direct keys). Before the fix, the credentials provider never
+    /// received the config file path, so these credentials would not resolve.
+    #[tokio::test]
+    async fn profile_credentials_resolved_from_config_file_only() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config_creds_in_config/config"),
+            None,
+            "creds-in-config",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+        let provider = sdk_config.credentials_provider().unwrap();
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "config_file_access_key");
+        assert_eq!(creds.secret_access_key(), "config_file_secret_key");
+    }
+
+    /// Only config file — region resolves from config file.
+    #[tokio::test]
+    async fn profile_region_resolved_from_config_file_only() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config_creds_in_config/config"),
+            None,
+            "creds-in-config",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+
+        assert_eq!(sdk_config.region().unwrap().to_string(), "eu-central-1");
+    }
+
+    /// Both files, credentials in config file (not credentials file) —
+    /// verifies the credentials provider searches the config file.
+    #[tokio::test]
+    async fn profile_credentials_in_config_with_both_files() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config_creds_in_config/config"),
+            Some("./test_data/test_config_creds_in_config/credentials"),
+            "creds-in-config",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+        let provider = sdk_config.credentials_provider().unwrap();
+        let creds = provider.provide_credentials().await.unwrap();
+
+        // "creds-in-config" profile only exists in the config file,
+        // so credentials must come from there.
+        assert_eq!(creds.access_key_id(), "config_file_access_key");
+        assert_eq!(creds.secret_access_key(), "config_file_secret_key");
+    }
+
+    /// Default profile — both files provided, credentials from credentials file.
+    #[tokio::test]
+    async fn profile_default_credentials_with_both_files() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config/config"),
+            Some("./test_data/test_config/credentials"),
+            "default",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+        let provider = sdk_config.credentials_provider().unwrap();
+        let creds = provider.provide_credentials().await.unwrap();
+
+        assert_eq!(creds.access_key_id(), "my_default_profile_access_key");
+        assert_eq!(
+            creds.secret_access_key(),
+            "my_default_profile_secret_access_key"
+        );
+        assert_eq!(
+            creds.session_token(),
+            Some("my_default_profile_session_token")
+        );
+    }
+
+    /// Default profile — region from config file.
+    #[tokio::test]
+    async fn profile_default_region_from_config_file() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config/config"),
+            Some("./test_data/test_config/credentials"),
+            "default",
+            None,
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+
+        assert_eq!(sdk_config.region().unwrap().to_string(), "us-west-1");
+    }
+
+    /// CLI region overrides config file region.
+    #[tokio::test]
+    async fn profile_cli_region_overrides_config_file() {
+        init_dummy_tracing_subscriber();
+
+        let config = profile_client_config(
+            Some("./test_data/test_config/config"),
+            Some("./test_data/test_config/credentials"),
+            "aws",
+            Some("cli-override-region"),
+        );
+
+        let sdk_config = config.load_sdk_config().await;
+
+        assert_eq!(
+            sdk_config.region().unwrap().to_string(),
+            "cli-override-region"
+        );
     }
 
     #[tokio::test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -516,10 +516,30 @@ impl Debug for AccessKeys {
             .session_token
             .as_ref()
             .map_or("None", |_| "** redacted **");
-        keys.field("access_key", &self.access_key)
+        let masked_access_key = mask_access_key(&self.access_key);
+        keys.field("access_key", &masked_access_key)
             .field("secret_access_key", &"** redacted **")
             .field("session_token", &session_token);
         keys.finish()
+    }
+}
+
+/// Masks an access key, showing only the first 4 and last 4 characters.
+///
+/// Keys shorter than 9 characters are fully masked.
+pub(crate) fn mask_access_key(key: &str) -> String {
+    const PREFIX_LEN: usize = 4;
+    const SUFFIX_LEN: usize = 4;
+    if key.len() < PREFIX_LEN + SUFFIX_LEN + 1 {
+        "*".repeat(key.len())
+    } else {
+        let masked_len = key.len() - PREFIX_LEN - SUFFIX_LEN;
+        format!(
+            "{}{}{}",
+            &key[..PREFIX_LEN],
+            "*".repeat(masked_len),
+            &key[key.len() - SUFFIX_LEN..]
+        )
     }
 }
 
@@ -684,9 +704,132 @@ mod tests {
         };
         let debug_string = format!("{access_keys:?}");
 
+        assert!(debug_string.contains("access_key: \"AKIA************MPLE\""));
         assert!(debug_string.contains("secret_access_key: \"** redacted **\""));
         assert!(debug_string.contains("session_token: \"** redacted **\""));
         assert!(!debug_string.contains("wJalrXUtnFEMI"));
+        assert!(!debug_string.contains("AKIAIOSFODNN7EXAMPLE"));
+    }
+
+    #[test]
+    fn mask_access_key_empty_string() {
+        assert_eq!(super::mask_access_key(""), "");
+    }
+
+    #[test]
+    fn mask_access_key_single_char() {
+        assert_eq!(super::mask_access_key("A"), "*");
+    }
+
+    #[test]
+    fn mask_access_key_short_keys_fully_masked() {
+        assert_eq!(super::mask_access_key("AB"), "**");
+        assert_eq!(super::mask_access_key("ABCD"), "****");
+        assert_eq!(super::mask_access_key("ABCDEFG"), "*******");
+    }
+
+    #[test]
+    fn mask_access_key_eight_chars_fully_masked() {
+        // Exactly PREFIX_LEN + SUFFIX_LEN = 8, still fully masked
+        assert_eq!(super::mask_access_key("ABCDEFGH"), "********");
+    }
+
+    #[test]
+    fn mask_access_key_nine_chars_threshold() {
+        // First key length where partial masking applies: first 4 + 1 masked + last 4
+        assert_eq!(super::mask_access_key("ABCDEFGHI"), "ABCD*FGHI");
+    }
+
+    #[test]
+    fn mask_access_key_ten_chars() {
+        assert_eq!(super::mask_access_key("ABCDEFGHIJ"), "ABCD**GHIJ");
+    }
+
+    #[test]
+    fn mask_access_key_standard_aws_key() {
+        // AWS access key IDs are 20 characters starting with AKIA
+        let masked = super::mask_access_key("AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(masked, "AKIA************MPLE");
+        assert_eq!(masked.len(), 20);
+    }
+
+    #[test]
+    fn mask_access_key_preserves_length() {
+        for len in 0..=30 {
+            let input: String = "X".repeat(len);
+            let masked = super::mask_access_key(&input);
+            assert_eq!(
+                masked.len(),
+                input.len(),
+                "Masked output length must equal input length for {len}-char key"
+            );
+        }
+    }
+
+    #[test]
+    fn mask_access_key_prefix_and_suffix_preserved() {
+        let masked = super::mask_access_key("AKIAIOSFODNN7EXAMPLE");
+        assert!(masked.starts_with("AKIA"));
+        assert!(masked.ends_with("MPLE"));
+    }
+
+    #[test]
+    fn mask_access_key_middle_fully_masked() {
+        let masked = super::mask_access_key("AKIAIOSFODNN7EXAMPLE");
+        // Middle 12 chars should all be '*'
+        let middle = &masked[4..16];
+        assert!(
+            middle.chars().all(|c| c == '*'),
+            "Middle portion should be all asterisks, got: {middle}"
+        );
+    }
+
+    #[test]
+    fn mask_access_key_no_original_middle_leaked() {
+        let original = "AKIAIOSFODNN7EXAMPLE";
+        let masked = super::mask_access_key(original);
+        // The middle portion "IOSFODNN7EXA" must not appear in masked output
+        let original_middle = &original[4..16];
+        assert!(
+            !masked.contains(original_middle),
+            "Masked output must not contain the original middle portion"
+        );
+    }
+
+    #[test]
+    fn mask_access_key_short_key_no_chars_leaked() {
+        // For fully-masked keys, no original characters should be visible
+        let original = "ABCDEFGH";
+        let masked = super::mask_access_key(original);
+        assert!(
+            masked.chars().all(|c| c == '*'),
+            "Fully masked key should contain only asterisks"
+        );
+    }
+
+    #[test]
+    fn debug_access_keys_without_session_token() {
+        let access_keys = AccessKeys {
+            access_key: "AKIAIOSFODNN7EXAMPLE".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: None,
+        };
+        let debug_string = format!("{access_keys:?}");
+        assert!(debug_string.contains("access_key: \"AKIA************MPLE\""));
+        assert!(debug_string.contains("session_token: \"None\""));
+        assert!(!debug_string.contains("AKIAIOSFODNN7EXAMPLE"));
+    }
+
+    #[test]
+    fn debug_access_keys_with_short_key() {
+        let access_keys = AccessKeys {
+            access_key: "SHORT".to_string(),
+            secret_access_key: "secret".to_string(),
+            session_token: None,
+        };
+        let debug_string = format!("{access_keys:?}");
+        assert!(debug_string.contains("access_key: \"*****\""));
+        assert!(!debug_string.contains("SHORT"));
     }
 
     // --- ObjectKeyMap tests (Task 3.1) ---

--- a/test_data/test_config_creds_in_config/config
+++ b/test_data/test_config_creds_in_config/config
@@ -1,0 +1,7 @@
+[default]
+region = us-west-2
+
+[profile creds-in-config]
+aws_access_key_id = config_file_access_key
+aws_secret_access_key = config_file_secret_key
+region = eu-central-1

--- a/test_data/test_config_creds_in_config/credentials
+++ b/test_data/test_config_creds_in_config/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = default_creds_access_key
+aws_secret_access_key = default_creds_secret_key

--- a/tests/e2e_delete_marker_only.rs
+++ b/tests/e2e_delete_marker_only.rs
@@ -84,8 +84,7 @@ async fn e2e_filter_delete_marker_only_basic() {
         // Delete first 3 objects via normal API (creates delete markers)
         let mut delete_marker_ids = Vec::new();
         for i in 0..NUM_DELETED {
-            let dm_vid =
-                create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
+            let dm_vid = create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
             delete_marker_ids.push(dm_vid);
         }
 
@@ -99,8 +98,14 @@ async fn e2e_filter_delete_marker_only_basic() {
             .iter()
             .filter(|(k, _)| !k.starts_with("[delete-marker]"))
             .count();
-        assert_eq!(pre_markers, NUM_DELETED, "Should have {NUM_DELETED} delete markers before");
-        assert_eq!(pre_objects, NUM_OBJECTS, "Should have {NUM_OBJECTS} object versions before");
+        assert_eq!(
+            pre_markers, NUM_DELETED,
+            "Should have {NUM_DELETED} delete markers before"
+        );
+        assert_eq!(
+            pre_objects, NUM_OBJECTS,
+            "Should have {NUM_OBJECTS} object versions before"
+        );
 
         // Run with --filter-delete-marker-only
         let config = TestHelper::build_config(vec![
@@ -277,12 +282,18 @@ async fn e2e_filter_delete_marker_only_all_markers() {
                 .version_id(vid)
                 .send()
                 .await
-                .unwrap_or_else(|e| panic!("Failed to permanently delete {key} version {vid}: {e}"));
+                .unwrap_or_else(|e| {
+                    panic!("Failed to permanently delete {key} version {vid}: {e}")
+                });
         }
 
         // Verify: only delete markers remain
         let pre_versions = helper.list_object_versions(&bucket).await;
-        assert_eq!(pre_versions.len(), NUM_OBJECTS, "Should have {NUM_OBJECTS} items");
+        assert_eq!(
+            pre_versions.len(),
+            NUM_OBJECTS,
+            "Should have {NUM_OBJECTS} items"
+        );
         let pre_markers = pre_versions
             .iter()
             .filter(|(k, _)| k.starts_with("[delete-marker]"))
@@ -374,7 +385,11 @@ async fn e2e_filter_delete_marker_only_with_include_regex() {
 
         // Pre-conditions: 10 versions + 10 delete markers = 20 items
         let pre_versions = helper.list_object_versions(&bucket).await;
-        assert_eq!(pre_versions.len(), 20, "Should have 20 items before pipeline");
+        assert_eq!(
+            pre_versions.len(),
+            20,
+            "Should have 20 items before pipeline"
+        );
 
         let config = TestHelper::build_config(vec![
             &format!("s3://{bucket}/data/"),
@@ -466,7 +481,11 @@ async fn e2e_filter_delete_marker_only_dry_run() {
         }
 
         let pre_versions = helper.list_object_versions(&bucket).await;
-        assert_eq!(pre_versions.len(), NUM_OBJECTS + NUM_DELETED, "Pre-condition check");
+        assert_eq!(
+            pre_versions.len(),
+            NUM_OBJECTS + NUM_DELETED,
+            "Pre-condition check"
+        );
 
         let config = TestHelper::build_config(vec![
             &format!("s3://{bucket}/data/"),
@@ -539,12 +558,20 @@ async fn e2e_filter_delete_marker_only_multiple_versions_and_markers() {
 
         // Verify: 12 items total (6 versions + 6 markers)
         let pre_versions = helper.list_object_versions(&bucket).await;
-        assert_eq!(pre_versions.len(), NUM_KEYS * 4, "Should have 12 items before");
+        assert_eq!(
+            pre_versions.len(),
+            NUM_KEYS * 4,
+            "Should have 12 items before"
+        );
         let pre_marker_count = pre_versions
             .iter()
             .filter(|(k, _)| k.starts_with("[delete-marker]"))
             .count();
-        assert_eq!(pre_marker_count, NUM_KEYS * 2, "Should have 6 delete markers");
+        assert_eq!(
+            pre_marker_count,
+            NUM_KEYS * 2,
+            "Should have 6 delete markers"
+        );
 
         let config = TestHelper::build_config(vec![
             &format!("s3://{bucket}/data/"),
@@ -689,7 +716,11 @@ async fn e2e_filter_delete_marker_only_respects_prefix() {
 
         // Verify: 12 items total (6 per prefix: 3 versions + 3 markers)
         let pre_versions = helper.list_object_versions(&bucket).await;
-        assert_eq!(pre_versions.len(), 12, "Should have 12 items before pipeline");
+        assert_eq!(
+            pre_versions.len(),
+            12,
+            "Should have 12 items before pipeline"
+        );
 
         let config = TestHelper::build_config(vec![
             &format!("s3://{bucket}/target/"),

--- a/tests/e2e_delete_marker_only.rs
+++ b/tests/e2e_delete_marker_only.rs
@@ -775,3 +775,48 @@ async fn e2e_filter_delete_marker_only_respects_prefix() {
         guard.cleanup().await;
     });
 }
+
+// ---------------------------------------------------------------------------
+// Rejects non-versioned bucket
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_rejects_non_versioned_bucket() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only returns an error when
+        //          the target bucket does not have versioning enabled.
+        // Setup:   Create standard (non-versioned) bucket; upload 5 objects.
+        // Expected: Pipeline reports error; objects remain untouched.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_bucket(&bucket).await; // non-versioned
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            helper
+                .put_object(&bucket, &format!("data/file{i}.dat"), vec![b'd'; 100])
+                .await;
+        }
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            result.has_error,
+            "Pipeline should report error for --filter-delete-marker-only on non-versioned bucket"
+        );
+
+        // Objects should still exist (deletion was not performed)
+        let remaining = helper.count_objects(&bucket, "data/").await;
+        assert_eq!(remaining, 5, "All objects should remain untouched");
+
+        guard.cleanup().await;
+    });
+}

--- a/tests/e2e_delete_marker_only.rs
+++ b/tests/e2e_delete_marker_only.rs
@@ -1,0 +1,746 @@
+//! E2E tests for the --filter-delete-marker-only feature.
+//!
+//! Tests that --filter-delete-marker-only deletes only delete markers while
+//! retaining all object versions (both latest and non-latest) in versioned buckets.
+
+#![cfg(e2e_test)]
+
+mod common;
+
+use common::TestHelper;
+
+/// Helper: put an object and return its version ID.
+async fn put_object_versioned(
+    helper: &TestHelper,
+    bucket: &str,
+    key: &str,
+    body: Vec<u8>,
+) -> String {
+    let resp = helper
+        .client()
+        .put_object()
+        .bucket(bucket)
+        .key(key)
+        .body(body.into())
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("Failed to put object {key} in {bucket}: {e}"));
+    resp.version_id()
+        .unwrap_or_else(|| panic!("No version ID returned for {key}"))
+        .to_string()
+}
+
+/// Helper: delete an object via normal API and return the delete marker's version ID.
+async fn create_delete_marker(helper: &TestHelper, bucket: &str, key: &str) -> String {
+    let resp = helper
+        .client()
+        .delete_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("Failed to create delete marker for {key}: {e}"));
+    resp.version_id()
+        .unwrap_or_else(|| panic!("No version ID for delete marker {key}"))
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Basic: Only delete markers are deleted, object versions are retained
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_basic() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only deletes only delete markers
+        //          and retains all object versions.
+        // Setup:   Create versioned bucket; upload 5 objects; delete 3 via normal API
+        //          (creates 3 delete markers). Total: 5 versions + 3 markers = 8 items.
+        // Expected: 3 delete markers deleted; 5 object versions remain; each original
+        //           version ID is still present.
+
+        const NUM_OBJECTS: usize = 5;
+        const NUM_DELETED: usize = 3;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload objects and capture version IDs
+        let mut version_ids = Vec::new();
+        for i in 0..NUM_OBJECTS {
+            let vid = put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'v'; 100],
+            )
+            .await;
+            version_ids.push(vid);
+        }
+
+        // Delete first 3 objects via normal API (creates delete markers)
+        let mut delete_marker_ids = Vec::new();
+        for i in 0..NUM_DELETED {
+            let dm_vid =
+                create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
+            delete_marker_ids.push(dm_vid);
+        }
+
+        // Verify pre-conditions: 5 versions + 3 delete markers = 8 items
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        let pre_markers = pre_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .count();
+        let pre_objects = pre_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]"))
+            .count();
+        assert_eq!(pre_markers, NUM_DELETED, "Should have {NUM_DELETED} delete markers before");
+        assert_eq!(pre_objects, NUM_OBJECTS, "Should have {NUM_OBJECTS} object versions before");
+
+        // Run with --filter-delete-marker-only
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, NUM_DELETED as u64,
+            "Should delete only {NUM_DELETED} delete markers"
+        );
+
+        // Verify: no delete markers remain
+        let post_versions = helper.list_object_versions(&bucket).await;
+        let post_markers: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .collect();
+        assert!(
+            post_markers.is_empty(),
+            "No delete markers should remain; found {}",
+            post_markers.len()
+        );
+
+        // Verify: all original object versions are retained
+        let post_objects: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]"))
+            .collect();
+        assert_eq!(
+            post_objects.len(),
+            NUM_OBJECTS,
+            "All {NUM_OBJECTS} object versions should be retained"
+        );
+
+        // Verify: retained version IDs match the originals
+        let remaining_vids: Vec<&str> = post_objects.iter().map(|(_, vid)| vid.as_str()).collect();
+        for (i, expected_vid) in version_ids.iter().enumerate() {
+            assert!(
+                remaining_vids.contains(&expected_vid.as_str()),
+                "Version ID for file{i}.dat ({expected_vid}) should be retained"
+            );
+        }
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// No delete markers: nothing is deleted
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_no_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only with no delete markers
+        //          results in zero deletions (all items are filtered out).
+        // Setup:   Create versioned bucket; upload 5 objects with 2 versions each.
+        //          No delete markers present. Total: 10 object versions.
+        // Expected: 0 deletions; all 10 versions remain.
+
+        const NUM_OBJECTS: usize = 5;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload 2 versions per object
+        for i in 0..NUM_OBJECTS {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'v'; 100],
+            )
+            .await;
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'w'; 200],
+            )
+            .await;
+        }
+
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), 10, "Should have 10 versions before");
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 0,
+            "Should delete 0 objects (no delete markers)"
+        );
+
+        // Verify: all 10 versions remain
+        let post_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(
+            post_versions.len(),
+            10,
+            "All 10 versions should remain unchanged"
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// All items are delete markers: all are deleted
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_all_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that when all items in the version listing are delete markers,
+        //          --filter-delete-marker-only deletes all of them.
+        // Setup:   Create versioned bucket; upload 5 objects; delete all via normal API
+        //          (creates 5 delete markers); then delete ALL versions with --delete-all-versions
+        //          first to remove the original versions, leaving only delete markers.
+        //          Actually — simpler: upload 5 objects, delete each via normal API,
+        //          then use --filter-delete-marker-only. This keeps both versions + markers.
+        //          But we want ONLY markers — so we manually delete the object versions first.
+        // Adjusted: Upload 5 objects, create delete markers for all, then permanently
+        //           delete the original object versions via versioned delete.
+        //           Remaining: 5 delete markers only.
+        // Expected: 5 delete markers deleted; bucket is empty.
+
+        const NUM_OBJECTS: usize = 5;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload objects and capture version IDs
+        let mut original_vids = Vec::new();
+        for i in 0..NUM_OBJECTS {
+            let vid = put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'v'; 100],
+            )
+            .await;
+            original_vids.push((format!("data/file{i}.dat"), vid));
+        }
+
+        // Create delete markers for all objects
+        for i in 0..NUM_OBJECTS {
+            create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
+        }
+
+        // Permanently delete the original object versions (not the delete markers)
+        for (key, vid) in &original_vids {
+            helper
+                .client()
+                .delete_object()
+                .bucket(&bucket)
+                .key(key)
+                .version_id(vid)
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("Failed to permanently delete {key} version {vid}: {e}"));
+        }
+
+        // Verify: only delete markers remain
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), NUM_OBJECTS, "Should have {NUM_OBJECTS} items");
+        let pre_markers = pre_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .count();
+        assert_eq!(
+            pre_markers, NUM_OBJECTS,
+            "All {NUM_OBJECTS} items should be delete markers"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, NUM_OBJECTS as u64,
+            "Should delete all {NUM_OBJECTS} delete markers"
+        );
+
+        // Verify: bucket is empty
+        let post_versions = helper.list_object_versions(&bucket).await;
+        assert!(
+            post_versions.is_empty(),
+            "No items should remain; found {}",
+            post_versions.len()
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Combined with --filter-include-regex: only matching delete markers deleted
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_with_include_regex() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only combined with
+        //          --filter-include-regex only deletes delete markers whose keys
+        //          match the regex.
+        // Setup:   Create versioned bucket; upload 5 .log and 5 .dat files;
+        //          delete all via normal API (creates 10 delete markers).
+        //          Use include regex to target only .log files.
+        // Expected: Only 5 .log delete markers deleted; 5 .dat delete markers
+        //           and all 10 original versions remain.
+
+        const NUM_PER_TYPE: usize = 5;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Upload .log files
+        for i in 0..NUM_PER_TYPE {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.log"),
+                vec![b'a'; 100],
+            )
+            .await;
+        }
+
+        // Upload .dat files
+        for i in 0..NUM_PER_TYPE {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'b'; 100],
+            )
+            .await;
+        }
+
+        // Create delete markers for all files
+        for i in 0..NUM_PER_TYPE {
+            create_delete_marker(&helper, &bucket, &format!("data/file{i}.log")).await;
+        }
+        for i in 0..NUM_PER_TYPE {
+            create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
+        }
+
+        // Pre-conditions: 10 versions + 10 delete markers = 20 items
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), 20, "Should have 20 items before pipeline");
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--filter-include-regex",
+            r"\.log$",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, NUM_PER_TYPE as u64,
+            "Should delete only {NUM_PER_TYPE} .log delete markers"
+        );
+
+        // Verify: .log delete markers are gone
+        let post_versions = helper.list_object_versions(&bucket).await;
+        let log_markers: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]") && k.contains(".log"))
+            .collect();
+        assert!(
+            log_markers.is_empty(),
+            ".log delete markers should be deleted; found {}",
+            log_markers.len()
+        );
+
+        // Verify: .dat delete markers remain
+        let dat_markers: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]") && k.contains(".dat"))
+            .collect();
+        assert_eq!(
+            dat_markers.len(),
+            NUM_PER_TYPE,
+            ".dat delete markers should remain"
+        );
+
+        // Verify: all 10 original object versions remain
+        let object_versions: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]"))
+            .collect();
+        assert_eq!(
+            object_versions.len(),
+            NUM_PER_TYPE * 2,
+            "All 10 original versions should remain"
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Dry run: no delete markers are actually deleted
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_dry_run() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only with --dry-run reports
+        //          what would be deleted without actually deleting anything.
+        // Setup:   Create versioned bucket; upload 5 objects; delete 3 via normal API.
+        //          Total: 5 versions + 3 markers = 8 items.
+        // Expected: Dry run reports 3 deletions; S3 state unchanged (8 items remain).
+
+        const NUM_OBJECTS: usize = 5;
+        const NUM_DELETED: usize = 3;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..NUM_OBJECTS {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'v'; 100],
+            )
+            .await;
+        }
+        for i in 0..NUM_DELETED {
+            create_delete_marker(&helper, &bucket, &format!("data/file{i}.dat")).await;
+        }
+
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), NUM_OBJECTS + NUM_DELETED, "Pre-condition check");
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--dry-run",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Dry run should complete without errors");
+
+        // Verify: S3 state is unchanged
+        let post_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(
+            post_versions.len(),
+            pre_versions.len(),
+            "Dry run should not modify S3 state"
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Multiple versions with delete markers: only markers removed
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_multiple_versions_and_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify correct behavior with multiple object versions AND
+        //          multiple delete markers per key (upload → delete → re-upload → delete).
+        // Setup:   Create versioned bucket with 3 keys, each having:
+        //            v1 (original) → dm1 (delete marker) → v2 (re-upload) → dm2 (delete marker)
+        //          Total per key: 2 versions + 2 delete markers = 4 items.
+        //          Total: 3 keys × 4 items = 12 items.
+        // Expected: 6 delete markers deleted; 6 object versions remain.
+
+        const NUM_KEYS: usize = 3;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let mut all_version_ids = Vec::new();
+        let mut all_marker_ids = Vec::new();
+
+        for i in 0..NUM_KEYS {
+            let key = format!("data/file{i}.dat");
+
+            // v1
+            let v1 = put_object_versioned(&helper, &bucket, &key, vec![b'a'; 100]).await;
+            all_version_ids.push(v1);
+
+            // dm1
+            let dm1 = create_delete_marker(&helper, &bucket, &key).await;
+            all_marker_ids.push(dm1);
+
+            // v2 (re-upload after delete)
+            let v2 = put_object_versioned(&helper, &bucket, &key, vec![b'b'; 200]).await;
+            all_version_ids.push(v2);
+
+            // dm2
+            let dm2 = create_delete_marker(&helper, &bucket, &key).await;
+            all_marker_ids.push(dm2);
+        }
+
+        // Verify: 12 items total (6 versions + 6 markers)
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), NUM_KEYS * 4, "Should have 12 items before");
+        let pre_marker_count = pre_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .count();
+        assert_eq!(pre_marker_count, NUM_KEYS * 2, "Should have 6 delete markers");
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects,
+            (NUM_KEYS * 2) as u64,
+            "Should delete all 6 delete markers"
+        );
+
+        // Verify: no delete markers remain
+        let post_versions = helper.list_object_versions(&bucket).await;
+        let post_markers: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .collect();
+        assert!(
+            post_markers.is_empty(),
+            "No delete markers should remain; found {}",
+            post_markers.len()
+        );
+
+        // Verify: all 6 object versions are retained
+        let post_objects: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]"))
+            .collect();
+        assert_eq!(
+            post_objects.len(),
+            NUM_KEYS * 2,
+            "All 6 object versions should be retained"
+        );
+
+        // Verify: version IDs match
+        let remaining_vids: Vec<&str> = post_objects.iter().map(|(_, vid)| vid.as_str()).collect();
+        for vid in &all_version_ids {
+            assert!(
+                remaining_vids.contains(&vid.as_str()),
+                "Version ID {vid} should be retained"
+            );
+        }
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Empty versioned bucket: completes with 0 deletions
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_empty_bucket() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only on an empty versioned bucket
+        //          completes successfully with 0 deletions and no errors.
+        // Setup:   Create versioned bucket, upload nothing.
+        // Expected: Pipeline succeeds, 0 deletions, no errors.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Pipeline should complete without errors on empty bucket"
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 0,
+            "No objects to delete in empty bucket"
+        );
+        assert_eq!(result.stats.stats_failed_objects, 0, "No failures expected");
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Prefix boundary: only delete markers under the target prefix are deleted
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_delete_marker_only_respects_prefix() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-delete-marker-only only affects delete markers
+        //          under the specified prefix and leaves other prefixes untouched.
+        // Setup:   Create versioned bucket with two prefixes:
+        //          - target/: 3 objects + 3 delete markers
+        //          - other/:  3 objects + 3 delete markers
+        // Expected: Only target/ delete markers deleted; other/ completely untouched.
+
+        const NUM_PER_PREFIX: usize = 3;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // Setup target/ prefix
+        for i in 0..NUM_PER_PREFIX {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("target/file{i}.dat"),
+                vec![b't'; 100],
+            )
+            .await;
+        }
+        for i in 0..NUM_PER_PREFIX {
+            create_delete_marker(&helper, &bucket, &format!("target/file{i}.dat")).await;
+        }
+
+        // Setup other/ prefix
+        for i in 0..NUM_PER_PREFIX {
+            put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("other/file{i}.dat"),
+                vec![b'o'; 100],
+            )
+            .await;
+        }
+        for i in 0..NUM_PER_PREFIX {
+            create_delete_marker(&helper, &bucket, &format!("other/file{i}.dat")).await;
+        }
+
+        // Verify: 12 items total (6 per prefix: 3 versions + 3 markers)
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(pre_versions.len(), 12, "Should have 12 items before pipeline");
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/target/"),
+            "--filter-delete-marker-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, NUM_PER_PREFIX as u64,
+            "Should delete only {NUM_PER_PREFIX} target/ delete markers"
+        );
+
+        // Verify: target/ delete markers are gone
+        let post_versions = helper.list_object_versions(&bucket).await;
+        let target_markers: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]") && k.contains("target/"))
+            .collect();
+        assert!(
+            target_markers.is_empty(),
+            "target/ delete markers should be deleted"
+        );
+
+        // Verify: target/ object versions remain
+        let target_versions: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]") && k.contains("target/"))
+            .collect();
+        assert_eq!(
+            target_versions.len(),
+            NUM_PER_PREFIX,
+            "target/ object versions should be retained"
+        );
+
+        // Verify: other/ is completely untouched (3 versions + 3 markers)
+        let other_items: Vec<_> = post_versions
+            .iter()
+            .filter(|(k, _)| {
+                let key = k.strip_prefix("[delete-marker]").unwrap_or(k);
+                key.starts_with("other/")
+            })
+            .collect();
+        assert_eq!(
+            other_items.len(),
+            NUM_PER_PREFIX * 2,
+            "other/ should be completely untouched (versions + markers)"
+        );
+
+        guard.cleanup().await;
+    });
+}


### PR DESCRIPTION
Add a new pipeline filter that passes only delete marker entries, filtering out all object versions. This enables "undelete" workflows by removing delete markers so underlying versions become visible again. The filter requires --delete-all-versions and executes first in the filter chain for early elimination.

Includes 18 unit/integration tests, 8 E2E tests, updated specs, README, CHANGELOG, and dependency upgrades (tokio 1.51, aws-sdk-s3 1.129, clap_complete 4.6.2, uuid 1.23).

> **Important:** All code, tests, and documentation in this repository are created and maintained exclusively by AI. We do not accept pull requests. If you find a bug or have a feature request, please [open an issue](https://github.com/nidor1998/s3rm-rs/issues) instead — describe your request in the ticket, and we'll consider having AI handle it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--filter-delete-marker-only` CLI flag to delete only S3 delete markers while preserving object versions (requires `--delete-all-versions`).

* **Dependencies**
  * Updated tokio, aws-sdk-s3, clap_complete, uuid, and 36 transitive dependencies.

* **Tests**
  * Added 8 E2E test scenarios covering delete-marker-only filtering functionality.
  * Added property-based tests for access key masking validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->