### PR TITLE
Release v1.3.6

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,8 +9,24 @@ env:
   APP_NAME: s3rm
 
 jobs:
+  create-release:
+    name: create draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: create draft release
+        uses: softprops/action-gh-release@v3
+        with:
+          draft: true
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   release-linux:
     name: release for linux
+    needs: create-release
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux_2_28_x86_64
     permissions:
@@ -57,6 +73,7 @@ jobs:
 
   release-linux-musl:
     name: release for linux musl
+    needs: create-release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -103,6 +120,7 @@ jobs:
 
   release-arm-linux:
     name: release for arm64 linux
+    needs: create-release
     runs-on: ubuntu-24.04-arm
     container: quay.io/pypa/manylinux_2_28_aarch64
     permissions:
@@ -149,6 +167,7 @@ jobs:
 
   release-arm-linux-musl:
     name: release for arm64 linux musl
+    needs: create-release
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: write
@@ -196,6 +215,7 @@ jobs:
 
   release-others:
     name: release for ${{ matrix.os }}
+    needs: create-release
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.3.6] - 2026-05-02
+
+### Changed
+
+- The deletion summary log message is now prefixed with `[dry-run]` when running in dry-run mode (`[dry-run] deletion summary`), making it easier to distinguish dry-run output from real deletions
+- `--dry-run`/`-d` and `--force`/`-f` are now mutually exclusive at the CLI level. Dry-run never deletes anything, so combining it with `--force` was always redundant; clap now rejects the combination with a clear conflict error
+- CD workflow now creates a draft GitHub release before the per-platform release jobs run, so all artifacts are uploaded to a single draft release rather than racing to create one
+
 ## [v1.3.5] - 2026-05-02
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,7 +2626,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.3.5"
+version = "1.3.6"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/examples/library_usage.rs
+++ b/examples/library_usage.rs
@@ -8,7 +8,7 @@
 //!
 //! Run with:
 //! ```sh
-//! cargo run --example library_usage -- s3://my-bucket/prefix/ --dry-run --force
+//! cargo run --example library_usage -- s3://my-bucket/prefix/ --dry-run
 //! ```
 
 use anyhow::Result;

--- a/src/bin/s3rm/indicator.rs
+++ b/src/bin/s3rm/indicator.rs
@@ -102,8 +102,14 @@ pub fn show_indicator(
                         objects_per_sec = 0;
                     }
 
+                    let summary_message = if dry_run {
+                        "[dry-run] deletion summary"
+                    } else {
+                        "deletion summary"
+                    };
+
                     info!(
-                        message = "deletion summary",
+                        message = summary_message,
                         deleted_bytes = total_delete_bytes,
                         deleted_objects = total_delete_count,
                         deleted_objects_per_sec = objects_per_sec,

--- a/src/bin/s3rm/main.rs
+++ b/src/bin/s3rm/main.rs
@@ -314,13 +314,12 @@ mod tests {
         );
     }
 
-    /// When --force is used with --dry-run and the endpoint is
-    /// unreachable the pipeline still records listing errors.
+    /// When --dry-run is used and the endpoint is unreachable the pipeline
+    /// still records listing errors.
     #[tokio::test]
     async fn pipeline_run_dry_run_errors_on_unreachable_endpoint() {
         let args = vec![
             "s3rm",
-            "-f",
             "-d",
             "--target-access-key",
             "dummy",

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -121,7 +121,7 @@ pub struct CLIArgs {
     // General options
     // -----------------------------------------------------------------------
     /// List objects that would be deleted without actually deleting them
-    #[arg(short = 'd', long, env, default_value_t = DEFAULT_DRY_RUN, help_heading = "General")]
+    #[arg(short = 'd', long, env, default_value_t = DEFAULT_DRY_RUN, conflicts_with = "force", help_heading = "General")]
     pub dry_run: bool,
 
     /// Skip the confirmation prompt before deleting

--- a/src/config/args/tests.rs
+++ b/src/config/args/tests.rs
@@ -242,7 +242,6 @@ fn config_from_full_args() {
         "s3rm",
         "s3://bucket/logs/",
         "--dry-run",
-        "--force",
         "--batch-size",
         "500",
         "--worker-size",
@@ -257,7 +256,7 @@ fn config_from_full_args() {
     let config = Config::try_from(cli).unwrap();
 
     assert!(config.dry_run);
-    assert!(config.force);
+    assert!(!config.force);
     assert_eq!(config.batch_size, 500);
     assert_eq!(config.worker_size, 50);
     assert!(config.delete_all_versions);
@@ -469,10 +468,20 @@ fn config_target_client_config_from_environment() {
 fn build_config_from_args_convenience() {
     init_dummy_tracing_subscriber();
 
-    let args = vec!["s3rm", "s3://bucket/prefix/", "--dry-run", "--force"];
+    let args = vec!["s3rm", "s3://bucket/prefix/", "--dry-run"];
     let config = build_config_from_args(args).unwrap();
     assert!(config.dry_run);
-    assert!(config.force);
+    assert!(!config.force);
+}
+
+#[test]
+fn dry_run_and_force_conflict() {
+    let args = vec!["s3rm", "s3://bucket/prefix/", "--dry-run", "--force"];
+    let result = build_config_from_args(args);
+    assert!(
+        result.is_err(),
+        "--dry-run and --force should conflict at the CLI level"
+    );
 }
 
 #[test]
@@ -1082,7 +1091,6 @@ fn config_from_full_args_with_if_match() {
         "s3rm",
         "s3://bucket/prefix/",
         "--dry-run",
-        "--force",
         "--batch-size",
         "500",
         "--worker-size",
@@ -1097,7 +1105,7 @@ fn config_from_full_args_with_if_match() {
     let config = Config::try_from(cli).unwrap();
 
     assert!(config.dry_run);
-    assert!(config.force);
+    assert!(!config.force);
     assert_eq!(config.batch_size, 500);
     assert_eq!(config.worker_size, 50);
     assert!(config.if_match);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,7 +24,7 @@ use fancy_regex::Regex;
 ///
 /// ```no_run
 /// let config = s3rm_rs::build_config_from_args([
-///     "s3rm", "s3://my-bucket/logs/2024/", "--dry-run", "--force",
+///     "s3rm", "s3://my-bucket/logs/2024/", "--dry-run",
 /// ]).expect("invalid arguments");
 /// ```
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@ async fn main() {
         "s3rm",
         "s3://my-bucket/logs/2024/",
         "--dry-run",
-        "--force",
     ]).expect("invalid arguments");
 
     let token = create_pipeline_cancellation_token();

--- a/tests/e2e_combined.rs
+++ b/tests/e2e_combined.rs
@@ -137,7 +137,6 @@ async fn e2e_dry_run_with_delete_all_versions() {
             &format!("s3://{bucket}/dryver/"),
             "--dry-run",
             "--delete-all-versions",
-            "--force",
         ]);
         let result = TestHelper::run_pipeline(config).await;
 
@@ -203,7 +202,6 @@ async fn e2e_dry_run_with_filters() {
             "--dry-run",
             "--filter-include-regex",
             "^temp/",
-            "--force",
         ]);
         let result = TestHelper::run_pipeline(config).await;
 

--- a/tests/e2e_delete_marker_only.rs
+++ b/tests/e2e_delete_marker_only.rs
@@ -492,7 +492,6 @@ async fn e2e_filter_delete_marker_only_dry_run() {
             "--filter-delete-marker-only",
             "--delete-all-versions",
             "--dry-run",
-            "--force",
         ]);
         let result = TestHelper::run_pipeline(config).await;
 

--- a/tests/e2e_error.rs
+++ b/tests/e2e_error.rs
@@ -294,7 +294,7 @@ async fn e2e_exit_codes() {
         );
 
         // --- Exit code 0: successful dry-run ---
-        // Create a real bucket, upload an object, and run with --dry-run --force.
+        // Create a real bucket, upload an object, and run with --dry-run.
         let helper = TestHelper::new().await;
         let bucket = helper.generate_bucket_name();
         helper.create_bucket(&bucket).await;
@@ -309,7 +309,6 @@ async fn e2e_exit_codes() {
             .args([
                 &format!("s3://{bucket}/exit-test/"),
                 "--dry-run",
-                "--force",
                 "--target-profile",
                 "s3rm-e2e-test",
             ])

--- a/tests/e2e_keep_latest_only.rs
+++ b/tests/e2e_keep_latest_only.rs
@@ -830,7 +830,6 @@ async fn e2e_keep_latest_only_dry_run() {
             "--keep-latest-only",
             "--delete-all-versions",
             "--dry-run",
-            "--force",
         ]);
         let result = TestHelper::run_pipeline(config).await;
 

--- a/tests/e2e_safety.rs
+++ b/tests/e2e_safety.rs
@@ -42,10 +42,7 @@ async fn e2e_dry_run_no_deletion() {
                 .await;
         }
 
-        let config = TestHelper::build_config(vec![
-            &format!("s3://{bucket}/data/"),
-            "--dry-run",
-        ]);
+        let config = TestHelper::build_config(vec![&format!("s3://{bucket}/data/"), "--dry-run"]);
         let result = TestHelper::run_pipeline(config).await;
 
         assert!(

--- a/tests/e2e_safety.rs
+++ b/tests/e2e_safety.rs
@@ -45,7 +45,6 @@ async fn e2e_dry_run_no_deletion() {
         let config = TestHelper::build_config(vec![
             &format!("s3://{bucket}/data/"),
             "--dry-run",
-            "--force",
         ]);
         let result = TestHelper::run_pipeline(config).await;
 


### PR DESCRIPTION
- Prefix the deletion summary log with `[dry-run]` when running in dry-run mode so dry-run output is easy to distinguish from real deletions.
- Make `--dry-run`/`-d` and `--force`/`-f` mutually exclusive at the CLI level. Dry-run never deletes anything, so combining the two was always redundant; clap now rejects the combination with a clear conflict error.
- CD workflow now creates a draft GitHub release before the per-platform release jobs run, so all artifacts upload to a single draft release rather than racing to create one.

**Contributing**

- Suggestions and bug reports are welcome, but responses are not guaranteed.
- Pull requests for new features are generally not accepted, as they may conflict with the design philosophy.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project to be “complete” and will maintain it only minimally going forward.  
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `--dry-run` and `--force` command-line flags are now mutually exclusive. Attempting to use both flags together will result in a validation error from the CLI parser.
  * Deletion summary logs displayed during dry-run operations now include a `[dry-run]` prefix, making it clearer when operations are running in preview-only mode.
  * Version updated to 1.3.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->