### PR TITLE
Fix/fable 20260719

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- `--help` no longer prints the values of credential environment variables. `--target-access-key`, `--target-secret-access-key`, and `--target-session-token` are now marked `hide_env_values`, so a secret supplied via the environment-variable form is no longer echoed in help output (e.g. CI logs, terminal scrollback, or a pasted bug report)
+
+### Changed
+
+- Delete markers are now excluded from deletion by the size filters (`--filter-smaller-size`, `--filter-larger-size`) and the content-type/metadata/tag filters. A delete marker has no size, content type, metadata, or tags, and deleting a *latest* delete marker resurrects the object it hides — which an attribute-scoped run never intends. A full purge (`--delete-all-versions` with no such filter) and `--filter-delete-marker-only` still delete markers. Accordingly, `--filter-delete-marker-only` now conflicts with the size/content-type/metadata/tag filters (that combination selected nothing); modification-time and key-regex filters still apply to markers
+
 ### Fixed
 
 - Versioning-suspended buckets are now treated as versioned. A suspended bucket still retains all of its historical versions and delete markers, so `--delete-all-versions` now permanently removes them instead of degrading to versionless deletes (which merely added null delete markers and left the old versions billed and intact). `--keep-latest-only` and `--filter-delete-marker-only` also no longer wrongly reject suspended buckets as "non-versioned"
-- Delete markers no longer abort `--delete-all-versions` runs that use content-type/metadata/tag filters. `HeadObject`/`GetObjectTagging` on a delete-marker version returns HTTP 405, which previously cancelled the entire pipeline on the first marker. These filters now skip the API call for delete markers and evaluate them against absent values (an include filter drops the marker, an exclude filter keeps it)
+- Delete markers no longer abort `--delete-all-versions` runs that use content-type/metadata/tag filters. `HeadObject`/`GetObjectTagging` on a delete-marker version returns HTTP 405, which previously cancelled the entire pipeline on the first marker. These filters now skip the API call for delete markers (which are excluded from deletion — see the marker-exclusion change above)
 
 ## [1.3.8] - 2026-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Versioning-suspended buckets are now treated as versioned. A suspended bucket still retains all of its historical versions and delete markers, so `--delete-all-versions` now permanently removes them instead of degrading to versionless deletes (which merely added null delete markers and left the old versions billed and intact). `--keep-latest-only` and `--filter-delete-marker-only` also no longer wrongly reject suspended buckets as "non-versioned"
+- Delete markers no longer abort `--delete-all-versions` runs that use content-type/metadata/tag filters. `HeadObject`/`GetObjectTagging` on a delete-marker version returns HTTP 405, which previously cancelled the entire pipeline on the first marker. These filters now skip the API call for delete markers and evaluate them against absent values (an include filter drops the marker, an exclude filter keeps it)
+
 ## [1.3.8] - 2026-06-27
 
 Monthly update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,7 +2666,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.3.8"
+version = "1.3.9"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ This demo shows Express One Zone deleting approximately 34,000 objects per secon
     * [AI assessment of safety and correctness (by Claude, Anthropic)](#ai-assessment-of-safety-and-correctness-by-claude-anthropic)
     * [AI assessment of safety and correctness (by Codex)](#ai-assessment-of-safety-and-correctness-by-codex)
     * [AI assessment of safety and correctness (by Gemini)](#ai-assessment-of-safety-and-correctness-by-gemini)
+- [Security assumptions](#security-assumptions)
 - [Recommendation](#recommendation)
 - [Scope](#scope)
 - [Non-Goals](#non-goals)
@@ -1423,6 +1424,35 @@ s3rm-rs v1.2.2 is a masterclass in safe systems engineering for cloud storage. T
 **Gemini Assessment: S (Superior / Highly Recommended for Production Environments)**
 
 </details>
+
+## Security assumptions
+
+s3rm is built on a fundamental security assumption: **both the object storage system and the specific bucket you
+delete from must be trusted.**
+
+Within this trust model, s3rm implements the security measures you would reasonably expect of a deletion tool:
+encrypted transport (TLS/HTTPS) for data in transit, ETag-based optimistic locking (`--if-match`) for conditional
+deletion, and secure handling of credentials through the standard AWS credential providers. These measures protect the
+confidentiality and integrity of your operations against transport-level and accidental threats.
+
+However, s3rm assumes that the storage endpoint is honest and non-adversarial — that it correctly implements the S3
+API and returns the object listings, metadata, ETags, tags, and checksum values it actually stores, without tampering.
+Because s3rm decides *what* to delete from the listings and metadata the endpoint reports, its filtering and safety
+features — prefix scoping, regex/size/modified-time filters, user-defined metadata and tag filters, version handling,
+and `--if-match` — are **not** a defense against a malicious or compromised storage backend that deliberately returns
+falsified listings, forged metadata, or forged ETags. Against such an adversarial endpoint, these guarantees do not
+hold, and s3rm may delete objects it should have spared, or spare objects it should have deleted.
+
+Crucially, trust must extend to the **bucket**, not just the storage provider. Even when the object storage system
+itself is fully trustworthy, a bucket can still be adversarial — for example, a bucket you do not control, a shared
+bucket writable by others, or one whose objects, metadata, or tags were crafted by an attacker. If you delete *from*
+such a bucket, the data and metadata it serves are already untrusted at the source, and s3rm's guarantees no longer
+apply. A trusted storage provider hosting an untrusted bucket is, for the purposes of this security model, an untrusted
+source.
+
+Deleting from an untrusted, compromised, or non-conformant endpoint or bucket is outside s3rm's security model.
+Selecting a trustworthy storage provider, and ensuring that every bucket you delete from is one you control or trust —
+including its credentials, encryption, and access policies — remains your responsibility.
 
 ## Recommendation
 

--- a/README.md
+++ b/README.md
@@ -649,6 +649,22 @@ s3rm filters objects in the following order:
 
 Filters that require additional API calls (content type, metadata, tags) are applied last to minimize unnecessary requests.
 
+#### Delete markers and attribute filters
+
+Delete markers have no size, content-type, user metadata, or tags. When you run with `--delete-all-versions`, the
+size filters (`--filter-smaller-size`, `--filter-larger-size`) and the content-type, metadata, and tag filters
+therefore **exclude delete markers from deletion** — a delete marker cannot match a property it does not have, and
+deleting a *latest* delete marker would resurrect the object it hides, which an attribute-scoped run never intends.
+
+As a result:
+
+- A full purge (`--delete-all-versions` with no size/attribute filter) still deletes delete markers.
+- `--filter-delete-marker-only` still deletes delete markers, and can be combined with modification-time filters
+  (markers have a last-modified time). It cannot be combined with the size/content-type/metadata/tag filters, because
+  that would select nothing.
+- Modification-time filters (`--filter-mtime-before`, `--filter-mtime-after`) and key regex filters
+  (`--filter-include-regex`, `--filter-exclude-regex`) apply to delete markers normally.
+
 ### Confirmation prompt detail
 
 By default, s3rm displays a warning with the target S3 path in colored text and requires explicit confirmation before proceeding:

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -167,11 +167,26 @@ pub struct CLIArgs {
     pub keep_latest_only: bool,
 
     /// Delete only delete markers (requires --delete-all-versions)
+    ///
+    /// Delete markers have no size, content-type, metadata, or tags, so they are
+    /// excluded from those filters; combining them here would silently delete
+    /// nothing, hence the conflict. Modification-time filters still apply
+    /// (markers have a last-modified time).
     #[arg(
         long,
         env,
         default_value_t = false,
         requires = "delete_all_versions",
+        conflicts_with_all = [
+            "filter_include_content_type_regex",
+            "filter_exclude_content_type_regex",
+            "filter_include_metadata_regex",
+            "filter_exclude_metadata_regex",
+            "filter_include_tag_regex",
+            "filter_exclude_tag_regex",
+            "filter_larger_size",
+            "filter_smaller_size",
+        ],
         help_heading = "Filtering"
     )]
     pub filter_delete_marker_only: bool,
@@ -191,14 +206,16 @@ pub struct CLIArgs {
     #[arg(long, env, value_parser = value_parser::regex::parse_regex, help_heading = "Filtering",
         long_help = r#"Delete only objects whose content type matches this regular expression.
 This filter is applied after key, size, and time filters.
-May require an extra API call per object to retrieve content type."#)]
+May require an extra API call per object to retrieve content type.
+Delete markers have no content type and are excluded from deletion when this filter is active."#)]
     pub filter_include_content_type_regex: Option<String>,
 
     /// Skip objects whose content type matches this regex
     #[arg(long, env, value_parser = value_parser::regex::parse_regex, help_heading = "Filtering",
         long_help = r#"Skip objects whose content type matches this regular expression.
 This filter is applied after key, size, and time filters.
-May require an extra API call per object to retrieve content type."#)]
+May require an extra API call per object to retrieve content type.
+Delete markers have no content type and are excluded from deletion when this filter is active."#)]
     pub filter_exclude_content_type_regex: Option<String>,
 
     /// Delete only objects whose user-defined metadata matches this regex
@@ -207,6 +224,7 @@ May require an extra API call per object to retrieve content type."#)]
 Keys (lowercase) must be sorted alphabetically and separated by commas.
 This filter is applied after all other filters except tag filters.
 May require an extra API call per object to retrieve metadata.
+Delete markers have no metadata and are excluded from deletion when this filter is active.
 
 Example: "key1=(value1|value2),key2=value2""#)]
     pub filter_include_metadata_regex: Option<String>,
@@ -217,6 +235,7 @@ Example: "key1=(value1|value2),key2=value2""#)]
 Keys (lowercase) must be sorted alphabetically and separated by commas.
 This filter is applied after all other filters except tag filters.
 May require an extra API call per object to retrieve metadata.
+Delete markers have no metadata and are excluded from deletion when this filter is active.
 
 Example: "key1=(value1|value2),key2=value2""#)]
     pub filter_exclude_metadata_regex: Option<String>,
@@ -227,6 +246,7 @@ Example: "key1=(value1|value2),key2=value2""#)]
 Keys must be sorted alphabetically and separated by '&'.
 This filter is applied after all other filters.
 Requires an extra API call per object to retrieve tags.
+Delete markers cannot be tagged and are excluded from deletion when this filter is active.
 
 Example: "key1=(value1|value2)&key2=value2""#)]
     pub filter_include_tag_regex: Option<String>,
@@ -237,6 +257,7 @@ Example: "key1=(value1|value2)&key2=value2""#)]
 Keys must be sorted alphabetically and separated by '&'.
 This filter is applied after all other filters.
 Requires an extra API call per object to retrieve tags.
+Delete markers cannot be tagged and are excluded from deletion when this filter is active.
 
 Example: "key1=(value1|value2)&key2=value2""#)]
     pub filter_exclude_tag_regex: Option<String>,
@@ -268,7 +289,8 @@ Example: 2023-02-19T12:00:00Z"#
         value_parser = value_parser::human_bytes::check_human_bytes,
         help_heading = "Filtering",
         long_help = r#"Delete only objects smaller than the given size.
-Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB"#
+Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB
+Delete markers have no size and are excluded from deletion when this filter is active."#
     )]
     pub filter_smaller_size: Option<String>,
 
@@ -279,7 +301,8 @@ Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB"#
         value_parser = value_parser::human_bytes::check_human_bytes,
         help_heading = "Filtering",
         long_help = r#"Delete only objects larger than or equal to the given size.
-Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB"#
+Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB
+Delete markers have no size and are excluded from deletion when this filter is active."#
     )]
     pub filter_larger_size: Option<String>,
 
@@ -322,15 +345,15 @@ Supported suffixes: KB, KiB, MB, MiB, GB, GiB, TB, TiB"#
     pub target_profile: Option<String>,
 
     /// Target access key
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_secret_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_secret_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
     pub target_access_key: Option<String>,
 
     /// Target secret access key
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
     pub target_secret_access_key: Option<String>,
 
     /// Target session token
-    #[arg(long, env, conflicts_with_all = ["target_profile"], requires = "target_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
+    #[arg(long, env, hide_env_values = true, conflicts_with_all = ["target_profile"], requires = "target_access_key", value_parser = NonEmptyStringValueParser::new(), help_heading = "AWS Configuration")]
     pub target_session_token: Option<String>,
 
     /// AWS region for the target

--- a/src/config/args/tests.rs
+++ b/src/config/args/tests.rs
@@ -213,6 +213,19 @@ fn parse_missing_target() {
     assert!(result.is_err());
 }
 
+#[test]
+fn config_from_empty_bucket_target_is_err() {
+    init_dummy_tracing_subscriber();
+
+    // "s3:///prefix" passes the clap value-parser (starts with "s3://" and is
+    // longer than 5 chars) but has an empty bucket, so parse_target() rejects
+    // it while building the Config.
+    let args = vec!["s3rm", "s3:///prefix"];
+    let cli = parse_from_args(args).unwrap();
+    let result = Config::try_from(cli);
+    assert!(result.is_err());
+}
+
 // ---------------------------------------------------------------------------
 // Config::try_from tests
 // ---------------------------------------------------------------------------
@@ -1033,6 +1046,140 @@ fn parse_keep_latest_only_conflicts_with_mtime_after() {
         "2023-01-01T00:00:00Z",
     ];
     assert!(parse_from_args(args).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// --filter-delete-marker-only conflicts with attribute filters
+//
+// A delete marker has no size, content type, metadata, or tags, so combining
+// --filter-delete-marker-only with any of those filters would select nothing.
+// The argument parser rejects the combination. Modification-time and key-regex
+// filters still apply to markers, so those combinations are accepted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_include_content_type_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-include-content-type-regex",
+        "text/.*",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_exclude_content_type_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-exclude-content-type-regex",
+        "image/.*",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_include_metadata_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-include-metadata-regex",
+        "key=value",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_exclude_metadata_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-exclude-metadata-regex",
+        "key=value",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_include_tag_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-include-tag-regex",
+        "env=prod",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_exclude_tag_regex() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-exclude-tag-regex",
+        "env=dev",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_larger_size_filter() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-larger-size",
+        "1024",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_conflicts_with_smaller_size_filter() {
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-smaller-size",
+        "1024",
+    ];
+    assert!(parse_from_args(args).is_err());
+}
+
+#[test]
+fn parse_delete_marker_only_allows_mtime_and_key_regex_filters() {
+    // Modification-time and key-regex filters still apply to delete markers, so
+    // they must NOT conflict with --filter-delete-marker-only.
+    let args = vec![
+        "s3rm",
+        "s3://bucket/",
+        "--filter-delete-marker-only",
+        "--delete-all-versions",
+        "--filter-mtime-before",
+        "2023-01-01T00:00:00Z",
+        "--filter-include-regex",
+        r"\.log$",
+    ];
+    let cli = parse_from_args(args).expect("mtime/key-regex filters should be allowed");
+    let config = Config::try_from(cli).unwrap();
+    assert!(config.filter_config.delete_marker_only);
+    assert!(config.filter_config.before_time.is_some());
+    assert!(config.filter_config.include_regex.is_some());
 }
 
 #[test]

--- a/src/deleter/mod.rs
+++ b/src/deleter/mod.rs
@@ -255,21 +255,32 @@ impl ObjectDeleter {
         }
 
         let key = object.key();
-        let head_result = self
-            .base
-            .target
-            .head_object(key, object.version_id().map(|v| v.to_string()))
-            .await;
 
-        let head_output = match head_result {
-            Ok(output) => output,
-            Err(e) => {
-                return self.handle_api_error(&e, key, "head_object").await;
+        // Delete markers carry no content-type or user metadata, and HeadObject
+        // on a delete-marker version returns HTTP 405 (MethodNotAllowed) rather
+        // than a 404, which would otherwise cancel the whole pipeline. Skip the
+        // doomed API call and evaluate the filters against absent values, so an
+        // include filter drops the marker and an exclude filter keeps it —
+        // exactly how a real object with no content-type/metadata is treated.
+        let head_output = if object.is_delete_marker() {
+            None
+        } else {
+            let head_result = self
+                .base
+                .target
+                .head_object(key, object.version_id().map(|v| v.to_string()))
+                .await;
+
+            match head_result {
+                Ok(output) => Some(output),
+                Err(e) => {
+                    return self.handle_api_error(&e, key, "head_object").await;
+                }
             }
         };
 
         // Content-type filters
-        let content_type = head_output.content_type();
+        let content_type = head_output.as_ref().and_then(|o| o.content_type());
         if !self.decide_delete_by_regex(
             key,
             fc.include_content_type_regex.as_ref(),
@@ -295,7 +306,8 @@ impl ObjectDeleter {
 
         // Metadata filters
         let formatted_metadata = head_output
-            .metadata()
+            .as_ref()
+            .and_then(|o| o.metadata())
             .filter(|m| !m.is_empty())
             .map(format_metadata);
         let formatted_metadata_ref = formatted_metadata.as_deref();
@@ -337,21 +349,31 @@ impl ObjectDeleter {
         }
 
         let key = object.key();
-        let tagging_result = self
-            .base
-            .target
-            .get_object_tagging(key, object.version_id().map(|v| v.to_string()))
-            .await;
 
-        let tagging_output = match tagging_result {
-            Ok(output) => output,
-            Err(e) => {
-                return self.handle_api_error(&e, key, "get_object_tagging").await;
+        // Delete markers cannot be tagged, and GetObjectTagging on a
+        // delete-marker version returns HTTP 405 (MethodNotAllowed) rather than
+        // a 404, which would otherwise cancel the whole pipeline. Skip the
+        // doomed API call and evaluate the filters against absent tags, so an
+        // include filter drops the marker and an exclude filter keeps it.
+        let tagging_output = if object.is_delete_marker() {
+            None
+        } else {
+            let tagging_result = self
+                .base
+                .target
+                .get_object_tagging(key, object.version_id().map(|v| v.to_string()))
+                .await;
+
+            match tagging_result {
+                Ok(output) => Some(output),
+                Err(e) => {
+                    return self.handle_api_error(&e, key, "get_object_tagging").await;
+                }
             }
         };
 
-        let formatted_tags = format_tags(tagging_output.tag_set());
-        let formatted_tags_ref = Some(formatted_tags.as_str());
+        let formatted_tags = tagging_output.as_ref().map(|o| format_tags(o.tag_set()));
+        let formatted_tags_ref = formatted_tags.as_deref();
         if !self.decide_delete_by_regex(
             key,
             fc.include_tag_regex.as_ref(),

--- a/src/deleter/mod.rs
+++ b/src/deleter/mod.rs
@@ -86,6 +86,7 @@ const INCLUDE_METADATA_REGEX_FILTER_NAME: &str = "include_metadata_regex_filter"
 const EXCLUDE_METADATA_REGEX_FILTER_NAME: &str = "exclude_metadata_regex_filter";
 const INCLUDE_TAG_REGEX_FILTER_NAME: &str = "include_tag_regex_filter";
 const EXCLUDE_TAG_REGEX_FILTER_NAME: &str = "exclude_tag_regex_filter";
+const DELETE_MARKER_ATTRIBUTE_FILTER_NAME: &str = "delete_marker_attribute_filter";
 
 // ---------------------------------------------------------------------------
 // ObjectDeleter worker
@@ -256,26 +257,29 @@ impl ObjectDeleter {
 
         let key = object.key();
 
-        // Delete markers carry no content-type or user metadata, and HeadObject
-        // on a delete-marker version returns HTTP 405 (MethodNotAllowed) rather
-        // than a 404, which would otherwise cancel the whole pipeline. Skip the
-        // doomed API call and evaluate the filters against absent values, so an
-        // include filter drops the marker and an exclude filter keeps it —
-        // exactly how a real object with no content-type/metadata is treated.
-        let head_output = if object.is_delete_marker() {
-            None
-        } else {
-            let head_result = self
-                .base
-                .target
-                .head_object(key, object.version_id().map(|v| v.to_string()))
+        // A delete marker has no content-type or user metadata, so a
+        // content-type/metadata filter cannot meaningfully describe it. Exclude
+        // markers from deletion whenever such a filter is active: deleting a
+        // latest delete marker resurrects the object it hides, which an
+        // attribute-scoped run never intends. (This also avoids the HTTP 405 a
+        // HeadObject on a delete-marker version returns, which would otherwise
+        // cancel the whole pipeline.) A full purge without attribute filters, or
+        // an explicit --filter-delete-marker-only run, still deletes markers.
+        if object.is_delete_marker() {
+            self.emit_filter_skip(object, DELETE_MARKER_ATTRIBUTE_FILTER_NAME)
                 .await;
+            return Ok(true);
+        }
 
-            match head_result {
-                Ok(output) => Some(output),
-                Err(e) => {
-                    return self.handle_api_error(&e, key, "head_object").await;
-                }
+        let head_output = match self
+            .base
+            .target
+            .head_object(key, object.version_id().map(|v| v.to_string()))
+            .await
+        {
+            Ok(output) => Some(output),
+            Err(e) => {
+                return self.handle_api_error(&e, key, "head_object").await;
             }
         };
 
@@ -350,25 +354,29 @@ impl ObjectDeleter {
 
         let key = object.key();
 
-        // Delete markers cannot be tagged, and GetObjectTagging on a
-        // delete-marker version returns HTTP 405 (MethodNotAllowed) rather than
-        // a 404, which would otherwise cancel the whole pipeline. Skip the
-        // doomed API call and evaluate the filters against absent tags, so an
-        // include filter drops the marker and an exclude filter keeps it.
-        let tagging_output = if object.is_delete_marker() {
-            None
-        } else {
-            let tagging_result = self
-                .base
-                .target
-                .get_object_tagging(key, object.version_id().map(|v| v.to_string()))
+        // A delete marker cannot be tagged, so a tag filter cannot meaningfully
+        // describe it. Exclude markers from deletion whenever a tag filter is
+        // active: deleting a latest delete marker resurrects the object it
+        // hides, which a tag-scoped run never intends. (This also avoids the
+        // HTTP 405 a GetObjectTagging on a delete-marker version returns, which
+        // would otherwise cancel the whole pipeline.) A full purge without tag
+        // filters, or an explicit --filter-delete-marker-only run, still deletes
+        // markers.
+        if object.is_delete_marker() {
+            self.emit_filter_skip(object, DELETE_MARKER_ATTRIBUTE_FILTER_NAME)
                 .await;
+            return Ok(true);
+        }
 
-            match tagging_result {
-                Ok(output) => Some(output),
-                Err(e) => {
-                    return self.handle_api_error(&e, key, "get_object_tagging").await;
-                }
+        let tagging_output = match self
+            .base
+            .target
+            .get_object_tagging(key, object.version_id().map(|v| v.to_string()))
+            .await
+        {
+            Ok(output) => Some(output),
+            Err(e) => {
+                return self.handle_api_error(&e, key, "get_object_tagging").await;
             }
         };
 

--- a/src/deleter/tests.rs
+++ b/src/deleter/tests.rs
@@ -1207,6 +1207,47 @@ async fn object_deleter_delete_marker_skips_head_object_filter() {
     assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
 }
 
+// An exclude content-type filter must keep the delete marker (absent
+// content-type never matches the exclude pattern), and the HeadObject call must
+// still be skipped rather than cancelling the pipeline with a 405.
+#[tokio::test]
+async fn object_deleter_delete_marker_kept_by_exclude_content_type_filter() {
+    init_dummy_tracing_subscriber();
+    let (stats_sender, _stats_receiver) = async_channel::unbounded();
+    let (boxed, mock) = make_mock_storage_boxed(stats_sender);
+
+    *mock.head_object_error.lock().unwrap() = Some(anyhow::anyhow!(
+        "HeadObject must not be called for a delete marker"
+    ));
+
+    let (input_sender, input_receiver) = async_channel::bounded::<S3Object>(10);
+    let (output_sender, _output_receiver) = async_channel::bounded::<S3Object>(10);
+
+    let mut config = make_test_config();
+    config.filter_config.exclude_content_type_regex = Some(Regex::new("application/json").unwrap());
+    let stage = make_stage_with_mock(config, boxed, Some(input_receiver), Some(output_sender));
+
+    let stats_report = Arc::new(DeletionStatsReport::new());
+    let delete_counter = Arc::new(AtomicU64::new(0));
+    let mut deleter = ObjectDeleter::new(stage, 0, stats_report.clone(), delete_counter);
+
+    input_sender
+        .send(make_delete_marker("gone.txt", "v1"))
+        .await
+        .unwrap();
+    drop(input_sender);
+
+    deleter.delete().await.unwrap();
+
+    // HeadObject skipped; exclude filter + absent content-type → marker kept.
+    assert_eq!(mock.head_object_calls.lock().unwrap().len(), 0);
+    let batch_calls = mock.delete_objects_calls.lock().unwrap();
+    assert_eq!(batch_calls.len(), 1);
+    assert_eq!(batch_calls[0].identifiers.len(), 1);
+    assert_eq!(batch_calls[0].identifiers[0].key(), "gone.txt");
+    assert_eq!(batch_calls[0].identifiers[0].version_id(), Some("v1"));
+}
+
 // Same for tag filters: GetObjectTagging on a delete-marker version returns 405.
 // An exclude tag filter must keep the marker (absent tags never match), and the
 // GetObjectTagging call must be skipped rather than cancelling the pipeline.

--- a/src/deleter/tests.rs
+++ b/src/deleter/tests.rs
@@ -22,7 +22,8 @@ use crate::config::Config;
 use crate::stage::Stage;
 use crate::storage::StorageTrait;
 use crate::test_utils::{
-    init_dummy_tracing_subscriber, make_s3_object, make_test_config, make_versioned_s3_object,
+    init_dummy_tracing_subscriber, make_delete_marker, make_s3_object, make_test_config,
+    make_versioned_s3_object,
 };
 use crate::types::token::PipelineCancellationToken;
 use crate::types::{DeletionStatistics, S3Object};
@@ -1161,6 +1162,126 @@ async fn object_deleter_tag_exclude_filter() {
     assert_eq!(batch_calls.len(), 0);
     let single_calls = mock.delete_object_calls.lock().unwrap();
     assert_eq!(single_calls.len(), 0);
+}
+
+// A delete marker has no content-type / metadata and HeadObject on a
+// delete-marker version returns HTTP 405, which would cancel the whole
+// pipeline. The deleter must skip the HeadObject call entirely and evaluate the
+// filter against absent values (include filter → marker dropped).
+#[tokio::test]
+async fn object_deleter_delete_marker_skips_head_object_filter() {
+    init_dummy_tracing_subscriber();
+    let (stats_sender, _stats_receiver) = async_channel::unbounded();
+    let (boxed, mock) = make_mock_storage_boxed(stats_sender);
+
+    // If HeadObject is (wrongly) called for the marker, this error fires and the
+    // pipeline is cancelled with an Err — proving the call was NOT skipped.
+    *mock.head_object_error.lock().unwrap() = Some(anyhow::anyhow!(
+        "HeadObject must not be called for a delete marker"
+    ));
+
+    let (input_sender, input_receiver) = async_channel::bounded::<S3Object>(10);
+    let (output_sender, _output_receiver) = async_channel::bounded::<S3Object>(10);
+
+    let mut config = make_test_config();
+    config.filter_config.include_content_type_regex = Some(Regex::new("text/plain").unwrap());
+    let stage = make_stage_with_mock(config, boxed, Some(input_receiver), Some(output_sender));
+
+    let stats_report = Arc::new(DeletionStatsReport::new());
+    let delete_counter = Arc::new(AtomicU64::new(0));
+    let mut deleter = ObjectDeleter::new(stage, 0, stats_report.clone(), delete_counter);
+
+    input_sender
+        .send(make_delete_marker("gone.txt", "v1"))
+        .await
+        .unwrap();
+    drop(input_sender);
+
+    // No 405 crash: the worker completes normally.
+    deleter.delete().await.unwrap();
+
+    // HeadObject was never called for the delete marker.
+    assert_eq!(mock.head_object_calls.lock().unwrap().len(), 0);
+    // Include filter + absent content-type → marker filtered out (not deleted).
+    assert_eq!(mock.delete_objects_calls.lock().unwrap().len(), 0);
+    assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
+}
+
+// Same for tag filters: GetObjectTagging on a delete-marker version returns 405.
+// An exclude tag filter must keep the marker (absent tags never match), and the
+// GetObjectTagging call must be skipped rather than cancelling the pipeline.
+#[tokio::test]
+async fn object_deleter_delete_marker_kept_by_exclude_tag_filter() {
+    init_dummy_tracing_subscriber();
+    let (stats_sender, _stats_receiver) = async_channel::unbounded();
+    let (boxed, mock) = make_mock_storage_boxed(stats_sender);
+
+    // If GetObjectTagging is (wrongly) called, this error cancels the pipeline.
+    *mock.tagging_error.lock().unwrap() = Some(anyhow::anyhow!(
+        "GetObjectTagging must not be called for a delete marker"
+    ));
+
+    let (input_sender, input_receiver) = async_channel::bounded::<S3Object>(10);
+    let (output_sender, _output_receiver) = async_channel::bounded::<S3Object>(10);
+
+    let mut config = make_test_config();
+    config.filter_config.exclude_tag_regex = Some(Regex::new("retain=true").unwrap());
+    let stage = make_stage_with_mock(config, boxed, Some(input_receiver), Some(output_sender));
+
+    let stats_report = Arc::new(DeletionStatsReport::new());
+    let delete_counter = Arc::new(AtomicU64::new(0));
+    let mut deleter = ObjectDeleter::new(stage, 0, stats_report.clone(), delete_counter);
+
+    input_sender
+        .send(make_delete_marker("gone.txt", "v1"))
+        .await
+        .unwrap();
+    drop(input_sender);
+
+    deleter.delete().await.unwrap();
+
+    // Exclude filter + absent tags → marker kept and deleted (with its version).
+    let batch_calls = mock.delete_objects_calls.lock().unwrap();
+    assert_eq!(batch_calls.len(), 1);
+    assert_eq!(batch_calls[0].identifiers.len(), 1);
+    assert_eq!(batch_calls[0].identifiers[0].key(), "gone.txt");
+    assert_eq!(batch_calls[0].identifiers[0].version_id(), Some("v1"));
+}
+
+// Include tag filter: absent tags never match, so the marker is dropped, and the
+// GetObjectTagging call is still skipped (no 405 cancellation).
+#[tokio::test]
+async fn object_deleter_delete_marker_dropped_by_include_tag_filter() {
+    init_dummy_tracing_subscriber();
+    let (stats_sender, _stats_receiver) = async_channel::unbounded();
+    let (boxed, mock) = make_mock_storage_boxed(stats_sender);
+
+    *mock.tagging_error.lock().unwrap() = Some(anyhow::anyhow!(
+        "GetObjectTagging must not be called for a delete marker"
+    ));
+
+    let (input_sender, input_receiver) = async_channel::bounded::<S3Object>(10);
+    let (output_sender, _output_receiver) = async_channel::bounded::<S3Object>(10);
+
+    let mut config = make_test_config();
+    config.filter_config.include_tag_regex = Some(Regex::new("env=dev").unwrap());
+    let stage = make_stage_with_mock(config, boxed, Some(input_receiver), Some(output_sender));
+
+    let stats_report = Arc::new(DeletionStatsReport::new());
+    let delete_counter = Arc::new(AtomicU64::new(0));
+    let mut deleter = ObjectDeleter::new(stage, 0, stats_report.clone(), delete_counter);
+
+    input_sender
+        .send(make_delete_marker("gone.txt", "v1"))
+        .await
+        .unwrap();
+    drop(input_sender);
+
+    deleter.delete().await.unwrap();
+
+    // Include filter + absent tags → marker filtered out (not deleted).
+    assert_eq!(mock.delete_objects_calls.lock().unwrap().len(), 0);
+    assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
 }
 
 #[tokio::test]

--- a/src/deleter/tests.rs
+++ b/src/deleter/tests.rs
@@ -403,6 +403,17 @@ fn generate_tagging_string_some() {
     assert!(s.contains("app=test"));
 }
 
+#[test]
+fn generate_tagging_string_empty_tag_set() {
+    // An object with no tags yields an empty (but present) tag string.
+    let output = GetObjectTaggingOutput::builder()
+        .set_tag_set(Some(vec![]))
+        .build()
+        .unwrap();
+    let result = generate_tagging_string(&Some(output));
+    assert_eq!(result, Some(String::new()));
+}
+
 // ===========================================================================
 // Unit tests: BatchDeleter
 // ===========================================================================
@@ -1207,11 +1218,12 @@ async fn object_deleter_delete_marker_skips_head_object_filter() {
     assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
 }
 
-// An exclude content-type filter must keep the delete marker (absent
-// content-type never matches the exclude pattern), and the HeadObject call must
-// still be skipped rather than cancelling the pipeline with a 405.
+// When a content-type filter is active, a delete marker must be filtered out
+// (not deleted), so a content-type-scoped run cannot resurrect the object the
+// marker hides. The HeadObject call must still be skipped rather than cancelling
+// the pipeline with a 405.
 #[tokio::test]
-async fn object_deleter_delete_marker_kept_by_exclude_content_type_filter() {
+async fn object_deleter_delete_marker_excluded_by_exclude_content_type_filter() {
     init_dummy_tracing_subscriber();
     let (stats_sender, _stats_receiver) = async_channel::unbounded();
     let (boxed, mock) = make_mock_storage_boxed(stats_sender);
@@ -1239,20 +1251,18 @@ async fn object_deleter_delete_marker_kept_by_exclude_content_type_filter() {
 
     deleter.delete().await.unwrap();
 
-    // HeadObject skipped; exclude filter + absent content-type → marker kept.
+    // HeadObject skipped; a content-type filter is active → marker filtered out.
     assert_eq!(mock.head_object_calls.lock().unwrap().len(), 0);
-    let batch_calls = mock.delete_objects_calls.lock().unwrap();
-    assert_eq!(batch_calls.len(), 1);
-    assert_eq!(batch_calls[0].identifiers.len(), 1);
-    assert_eq!(batch_calls[0].identifiers[0].key(), "gone.txt");
-    assert_eq!(batch_calls[0].identifiers[0].version_id(), Some("v1"));
+    assert_eq!(mock.delete_objects_calls.lock().unwrap().len(), 0);
+    assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
 }
 
 // Same for tag filters: GetObjectTagging on a delete-marker version returns 405.
-// An exclude tag filter must keep the marker (absent tags never match), and the
-// GetObjectTagging call must be skipped rather than cancelling the pipeline.
+// When a tag filter is active, a delete marker must be filtered out (not
+// deleted), and the GetObjectTagging call must be skipped rather than cancelling
+// the pipeline.
 #[tokio::test]
-async fn object_deleter_delete_marker_kept_by_exclude_tag_filter() {
+async fn object_deleter_delete_marker_excluded_by_exclude_tag_filter() {
     init_dummy_tracing_subscriber();
     let (stats_sender, _stats_receiver) = async_channel::unbounded();
     let (boxed, mock) = make_mock_storage_boxed(stats_sender);
@@ -1281,12 +1291,9 @@ async fn object_deleter_delete_marker_kept_by_exclude_tag_filter() {
 
     deleter.delete().await.unwrap();
 
-    // Exclude filter + absent tags → marker kept and deleted (with its version).
-    let batch_calls = mock.delete_objects_calls.lock().unwrap();
-    assert_eq!(batch_calls.len(), 1);
-    assert_eq!(batch_calls[0].identifiers.len(), 1);
-    assert_eq!(batch_calls[0].identifiers[0].key(), "gone.txt");
-    assert_eq!(batch_calls[0].identifiers[0].version_id(), Some("v1"));
+    // A tag filter is active → marker filtered out (not deleted).
+    assert_eq!(mock.delete_objects_calls.lock().unwrap().len(), 0);
+    assert_eq!(mock.delete_object_calls.lock().unwrap().len(), 0);
 }
 
 // Include tag filter: absent tags never match, so the marker is dropped, and the

--- a/src/filters/larger_size.rs
+++ b/src/filters/larger_size.rs
@@ -2,7 +2,8 @@
 //!
 //! Reused from s3sync's `pipeline/filter/larger_size.rs`.
 //! Passes objects whose size is greater than or equal to the configured threshold.
-//! Delete markers always pass (they have no meaningful size).
+//! Delete markers are filtered out (they have no meaningful size, and deleting a
+//! latest delete marker would resurrect the object it hides).
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -38,8 +39,12 @@ impl ObjectFilter for LargerSizeFilter<'_> {
 }
 
 fn is_larger_or_equal(object: &S3Object, config: &FilterConfig) -> bool {
+    // A delete marker has no meaningful size, so a size filter cannot describe
+    // it. Filter it out rather than deleting it: removing a latest delete marker
+    // resurrects the object it hides, which a size-scoped run never intends. A
+    // full purge without a size filter still deletes markers.
     if object.is_delete_marker() {
-        return true;
+        return false;
     }
 
     let Some(larger_size) = config.larger_size else {
@@ -143,7 +148,9 @@ pub(crate) mod tests {
             ..Default::default()
         };
 
-        assert!(is_larger_or_equal(&delete_marker, &config));
+        // A delete marker has no meaningful size and must be filtered out so a
+        // size-scoped run cannot resurrect the object it hides.
+        assert!(!is_larger_or_equal(&delete_marker, &config));
     }
 
     #[test]

--- a/src/filters/mtime_after.rs
+++ b/src/filters/mtime_after.rs
@@ -195,4 +195,49 @@ pub(crate) mod tests {
 
         assert!(!is_after_or_equal(&object, &config));
     }
+
+    #[tokio::test]
+    async fn to_millis_overflow_returns_false() {
+        init_dummy_tracing_subscriber();
+
+        // DateTime::from_secs(i64::MAX) overflows when converting seconds to
+        // milliseconds, so to_millis() returns an error and the object is
+        // skipped (kept) to be safe.
+        let object = S3Object::NotVersioning(
+            Object::builder()
+                .key("overflow-millis")
+                .last_modified(DateTime::from_secs(i64::MAX))
+                .build(),
+        );
+
+        let config = FilterConfig {
+            after_time: Some(chrono::DateTime::from_str("2023-01-20T00:00:00.001Z").unwrap()),
+            ..Default::default()
+        };
+
+        assert!(!is_after_or_equal(&object, &config));
+    }
+
+    #[tokio::test]
+    async fn chrono_conversion_overflow_returns_false() {
+        init_dummy_tracing_subscriber();
+
+        // A timestamp whose seconds*1000 still fits in an i64 (so to_millis()
+        // succeeds) but is far beyond chrono's representable range, so the
+        // conversion to a chrono DateTime fails and the object is skipped
+        // (kept) to be safe.
+        let object = S3Object::NotVersioning(
+            Object::builder()
+                .key("overflow-chrono")
+                .last_modified(DateTime::from_secs(9_000_000_000_000_000))
+                .build(),
+        );
+
+        let config = FilterConfig {
+            after_time: Some(chrono::DateTime::from_str("2023-01-20T00:00:00.001Z").unwrap()),
+            ..Default::default()
+        };
+
+        assert!(!is_after_or_equal(&object, &config));
+    }
 }

--- a/src/filters/mtime_before.rs
+++ b/src/filters/mtime_before.rs
@@ -196,4 +196,49 @@ pub(crate) mod tests {
 
         assert!(!is_before(&object, &config));
     }
+
+    #[test]
+    fn to_millis_overflow_returns_false() {
+        init_dummy_tracing_subscriber();
+
+        // DateTime::from_secs(i64::MAX) overflows when converting seconds to
+        // milliseconds, so to_millis() returns an error and the object is
+        // skipped (kept) to be safe.
+        let object = S3Object::NotVersioning(
+            Object::builder()
+                .key("overflow-millis")
+                .last_modified(DateTime::from_secs(i64::MAX))
+                .build(),
+        );
+
+        let config = FilterConfig {
+            before_time: Some(chrono::DateTime::from_str("2023-01-20T00:00:00.001Z").unwrap()),
+            ..Default::default()
+        };
+
+        assert!(!is_before(&object, &config));
+    }
+
+    #[test]
+    fn chrono_conversion_overflow_returns_false() {
+        init_dummy_tracing_subscriber();
+
+        // A timestamp whose seconds*1000 still fits in an i64 (so to_millis()
+        // succeeds) but is far beyond chrono's representable range, so the
+        // conversion to a chrono DateTime fails and the object is skipped
+        // (kept) to be safe.
+        let object = S3Object::NotVersioning(
+            Object::builder()
+                .key("overflow-chrono")
+                .last_modified(DateTime::from_secs(9_000_000_000_000_000))
+                .build(),
+        );
+
+        let config = FilterConfig {
+            before_time: Some(chrono::DateTime::from_str("2023-01-20T00:00:00.001Z").unwrap()),
+            ..Default::default()
+        };
+
+        assert!(!is_before(&object, &config));
+    }
 }

--- a/src/filters/smaller_size.rs
+++ b/src/filters/smaller_size.rs
@@ -2,7 +2,8 @@
 //!
 //! Reused from s3sync's `pipeline/filter/smaller_size.rs`.
 //! Passes objects whose size is strictly less than the configured threshold.
-//! Delete markers always pass (they have no meaningful size).
+//! Delete markers are filtered out (they have no meaningful size, and deleting a
+//! latest delete marker would resurrect the object it hides).
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -38,8 +39,12 @@ impl ObjectFilter for SmallerSizeFilter<'_> {
 }
 
 fn is_smaller(object: &S3Object, config: &FilterConfig) -> bool {
+    // A delete marker has no meaningful size, so a size filter cannot describe
+    // it. Filter it out rather than deleting it: removing a latest delete marker
+    // resurrects the object it hides, which a size-scoped run never intends. A
+    // full purge without a size filter still deletes markers.
     if object.is_delete_marker() {
-        return true;
+        return false;
     }
 
     let Some(smaller_size) = config.smaller_size else {
@@ -144,7 +149,9 @@ pub(crate) mod tests {
             ..Default::default()
         };
 
-        assert!(is_smaller(&delete_marker, &config));
+        // A delete marker has no meaningful size and must be filtered out so a
+        // size-scoped run cannot resurrect the object it hides.
+        assert!(!is_smaller(&delete_marker, &config));
     }
 
     #[test]

--- a/src/filters/user_defined.rs
+++ b/src/filters/user_defined.rs
@@ -287,4 +287,105 @@ mod tests {
         assert!(result.is_err());
         assert!(cancellation_token.is_cancelled());
     }
+
+    #[tokio::test]
+    async fn filter_error_with_event_callback_triggers_error_event() {
+        use crate::callback::event_manager::EventManager;
+        use crate::callback::filter_manager::FilterManager;
+        use crate::types::event_callback::{EventCallback, EventData, EventType};
+        use crate::types::filter_callback::FilterCallback;
+        use anyhow::Result;
+        use async_trait::async_trait;
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        struct ErrorFilter;
+
+        #[async_trait]
+        impl FilterCallback for ErrorFilter {
+            async fn filter(&mut self, _object: &S3Object) -> Result<bool> {
+                Err(anyhow::anyhow!("boom"))
+            }
+        }
+
+        /// Collects events for test assertions.
+        struct CollectingCallback {
+            events: Arc<Mutex<Vec<EventData>>>,
+        }
+
+        #[async_trait]
+        impl EventCallback for CollectingCallback {
+            async fn on_event(&mut self, event_data: EventData) {
+                self.events.lock().await.push(event_data);
+            }
+        }
+
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (mut base, _next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+
+        // Register a filter callback that always errors.
+        let mut manager = FilterManager::new();
+        manager.register_callback(ErrorFilter);
+        base.config.filter_manager = manager;
+
+        // Register an event callback so the error path emits a PIPELINE_ERROR event.
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let mut event_manager = EventManager::new();
+        event_manager.register_callback(
+            EventType::ALL_EVENTS,
+            CollectingCallback {
+                events: events.clone(),
+            },
+            false,
+        );
+        base.config.event_manager = event_manager;
+
+        let filter = UserDefinedFilter::new(base);
+        let object = S3Object::NotVersioning(Object::builder().key("error-me").build());
+
+        sender.send(object).await.unwrap();
+        sender.close();
+
+        let result = filter.filter().await;
+        assert!(result.is_err());
+        assert!(cancellation_token.is_cancelled());
+
+        let collected = events.lock().await;
+        assert_eq!(collected.len(), 1);
+        assert_eq!(collected[0].event_type, EventType::PIPELINE_ERROR);
+        assert!(
+            collected[0]
+                .message
+                .as_ref()
+                .unwrap()
+                .contains("User defined filter error")
+        );
+    }
+
+    #[tokio::test]
+    async fn send_returns_ok_when_next_stage_closed() {
+        init_dummy_tracing_subscriber();
+
+        let (sender, receiver) = async_channel::bounded::<S3Object>(1000);
+        let cancellation_token = token::create_pipeline_cancellation_token();
+        let (base, next_stage_receiver) =
+            create_base_helper(receiver, cancellation_token.clone()).await;
+
+        // Close the downstream channel so that send() reports SendResult::Closed
+        // and the worker returns Ok(()) early.
+        drop(next_stage_receiver);
+
+        let filter = UserDefinedFilter::new(base);
+        // No callback registered, so the object passes through and is sent.
+        let object = S3Object::NotVersioning(Object::builder().key("test-key").build());
+
+        sender.send(object).await.unwrap();
+        sender.close();
+
+        filter.filter().await.unwrap();
+    }
 }

--- a/src/property_tests/filter_properties.rs
+++ b/src/property_tests/filter_properties.rs
@@ -418,7 +418,7 @@ mod tests {
         }
 
         #[test]
-        fn test_delete_markers_pass_size_filters(
+        fn test_delete_markers_filtered_out_by_size_filters(
             threshold in 1u64..10000,
         ) {
             let delete_marker = S3Object::DeleteMarker(
@@ -434,9 +434,11 @@ mod tests {
                 ..Default::default()
             };
 
-            // Delete markers always pass size filters
-            prop_assert!(crate::filters::larger_size::tests::test_is_larger_or_equal(&delete_marker, &larger_config));
-            prop_assert!(crate::filters::smaller_size::tests::test_is_smaller(&delete_marker, &smaller_config));
+            // A delete marker has no meaningful size, so a size filter always
+            // filters it out — deleting a latest marker would resurrect the
+            // object it hides.
+            prop_assert!(!crate::filters::larger_size::tests::test_is_larger_or_equal(&delete_marker, &larger_config));
+            prop_assert!(!crate::filters::smaller_size::tests::test_is_smaller(&delete_marker, &smaller_config));
         }
     }
 

--- a/src/property_tests/safety_properties.rs
+++ b/src/property_tests/safety_properties.rs
@@ -559,4 +559,19 @@ mod tests {
         let result = checker.check_before_deletion();
         assert!(result.is_ok());
     }
+
+    /// The real `StdioPromptHandler::is_interactive()` reports whether both
+    /// stdin and stdout are TTYs. Under the test harness at least one of them is
+    /// typically redirected, so the call must not block and must return a bool.
+    /// This exercises the production TTY-detection path without touching stdin.
+    #[test]
+    fn stdio_prompt_handler_is_interactive_returns_bool() {
+        use crate::safety::StdioPromptHandler;
+
+        let handler = StdioPromptHandler;
+        // We can't assert a fixed value (it depends on how the test binary is
+        // launched), but the call must complete without blocking and yield a
+        // boolean.
+        let _: bool = handler.is_interactive();
+    }
 }

--- a/src/storage/s3/mod.rs
+++ b/src/storage/s3/mod.rs
@@ -331,7 +331,7 @@ impl StorageTrait for S3Storage {
                 anyhow::anyhow!(e).context("aws_sdk_s3::client::get_bucket_versioning() failed.")
             })?;
 
-        Ok(response.status() == Some(&aws_sdk_s3::types::BucketVersioningStatus::Enabled))
+        Ok(is_versioned_status(response.status()))
     }
 
     fn get_client(&self) -> Option<Arc<Client>> {
@@ -852,6 +852,22 @@ fn is_express_onezone_bucket(bucket: &str) -> bool {
     bucket.ends_with(EXPRESS_ONEZONE_STORAGE_SUFFIX)
 }
 
+/// Map a `GetBucketVersioning` status to whether the bucket holds versions.
+///
+/// A `Suspended` bucket still retains all of its historical versions and delete
+/// markers; only new writes stop being versioned. Both `Enabled` and
+/// `Suspended` are therefore treated as versioned, so `--delete-all-versions`
+/// actually removes those retained versions (rather than degrading to null
+/// delete markers) and `--keep-latest-only` / `--filter-delete-marker-only`
+/// work against them. A bucket that was never versioned reports no status.
+fn is_versioned_status(status: Option<&aws_sdk_s3::types::BucketVersioningStatus>) -> bool {
+    matches!(
+        status,
+        Some(&aws_sdk_s3::types::BucketVersioningStatus::Enabled)
+            | Some(&aws_sdk_s3::types::BucketVersioningStatus::Suspended)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1246,6 +1262,20 @@ mod tests {
             err_msg.contains("get_bucket_versioning() failed"),
             "Expected error to contain 'get_bucket_versioning() failed', got: {err_msg}"
         );
+    }
+
+    #[test]
+    fn is_versioned_status_treats_enabled_and_suspended_as_versioned() {
+        use aws_sdk_s3::types::BucketVersioningStatus;
+
+        // Enabled and Suspended buckets both retain versions.
+        assert!(is_versioned_status(Some(&BucketVersioningStatus::Enabled)));
+        assert!(is_versioned_status(Some(
+            &BucketVersioningStatus::Suspended
+        )));
+
+        // A bucket that was never versioned reports no status.
+        assert!(!is_versioned_status(None));
     }
 
     // ---------------------------------------------------------------

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,7 +4,7 @@
 //! modules, eliminating duplication and ensuring consistency.
 
 use aws_sdk_s3::primitives::DateTime;
-use aws_sdk_s3::types::{Object, ObjectVersion, ObjectVersionStorageClass};
+use aws_sdk_s3::types::{DeleteMarkerEntry, Object, ObjectVersion, ObjectVersionStorageClass};
 
 use crate::callback::event_manager::EventManager;
 use crate::callback::filter_manager::FilterManager;
@@ -72,6 +72,18 @@ pub(crate) fn make_s3_object(key: &str, size: i64) -> S3Object {
         Object::builder()
             .key(key)
             .size(size)
+            .last_modified(DateTime::from_secs(1000))
+            .build(),
+    )
+}
+
+/// Create a [`S3Object::DeleteMarker`] with the given key and version ID.
+pub(crate) fn make_delete_marker(key: &str, version_id: &str) -> S3Object {
+    S3Object::DeleteMarker(
+        DeleteMarkerEntry::builder()
+            .key(key)
+            .version_id(version_id)
+            .is_latest(true)
             .last_modified(DateTime::from_secs(1000))
             .build(),
     )

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -1,0 +1,109 @@
+//! Integration tests that spawn the real `s3rm` binary to exercise the
+//! process-level exit-code paths in `src/bin/s3rm/main.rs`.
+//!
+//! Unlike the `e2e_*` suites, these tests never touch AWS: every scenario
+//! errors out during argument parsing or the pre-deletion safety check, before
+//! any S3 request is made. They are therefore safe to run in normal
+//! `cargo test` runs and cover the `run()` / `load_config_exit_if_err()` exit
+//! branches that unit tests cannot reach (those call `std::process::exit`).
+
+use std::process::{Command, Stdio};
+
+/// Path to the compiled `s3rm` binary, provided by Cargo for integration tests.
+fn s3rm_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_s3rm")
+}
+
+/// Base command with stdin/stdout/stderr detached from any TTY so the safety
+/// check treats the environment as non-interactive.
+fn base_command() -> Command {
+    let mut cmd = Command::new(s3rm_bin());
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Avoid reading any real AWS configuration from the developer's machine.
+    cmd.arg("--aws-config-file")
+        .arg("./test_data/test_config/config")
+        .arg("--aws-shared-credentials-file")
+        .arg("./test_data/test_config/credentials")
+        .arg("--target-access-key")
+        .arg("dummy")
+        .arg("--target-secret-access-key")
+        .arg("dummy");
+    cmd
+}
+
+/// An `s3://` target with an empty bucket passes the clap value-parser (it
+/// starts with `s3://` and is longer than five characters) but is rejected by
+/// `parse_target()` while building the `Config`. `load_config_exit_if_err()`
+/// then turns that into a clap `ValueValidation` error and exits with code 2.
+#[test]
+fn empty_bucket_target_exits_with_config_error() {
+    let output = base_command()
+        .arg("s3:///prefix")
+        .output()
+        .expect("failed to spawn s3rm");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "empty-bucket target should exit with code 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Running a destructive deletion in a non-interactive environment (no TTY)
+/// without `--force` and without `--dry-run` must fail the safety check. This
+/// drives `run()` -> `check_prerequisites()` -> the non-cancelled error branch,
+/// which exits with the `InvalidConfig` exit code (2) without contacting S3.
+#[test]
+fn non_interactive_without_force_exits_with_config_error() {
+    let output = base_command()
+        .arg("s3://test-bucket/prefix/")
+        .output()
+        .expect("failed to spawn s3rm");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "non-interactive run without --force should exit with code 2; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--force"),
+        "error should mention the --force requirement; stderr: {stderr}"
+    );
+}
+
+/// `--dry-run` skips the confirmation prompt, so a non-interactive environment
+/// is allowed. With an unreachable endpoint the listing phase fails and the
+/// process exits non-zero via `run()`'s error-handling branch — but never with
+/// the abnormal-termination code (101), which is reserved for panics.
+#[test]
+fn dry_run_unreachable_endpoint_exits_nonzero_without_panic() {
+    let output = base_command()
+        .arg("--dry-run")
+        .arg("--target-endpoint-url")
+        .arg("https://anything.invalid")
+        .arg("--connect-timeout-milliseconds")
+        .arg("1")
+        .arg("--aws-max-attempts")
+        .arg("0")
+        .arg("s3://test-bucket/prefix/")
+        .output()
+        .expect("failed to spawn s3rm");
+
+    let code = output.status.code();
+    assert_ne!(
+        code,
+        Some(0),
+        "unreachable endpoint should not succeed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_ne!(
+        code,
+        Some(101),
+        "listing failure should be a normal error, not an abnormal termination"
+    );
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -154,6 +154,26 @@ impl TestHelper {
             .unwrap_or_else(|e| panic!("Failed to enable versioning on {bucket}: {e}"));
     }
 
+    /// Suspend versioning on an already-versioned bucket.
+    ///
+    /// A suspended bucket keeps all of its existing versions and delete markers
+    /// (only new writes stop being versioned), so it must still be treated as a
+    /// versioned bucket by `--delete-all-versions` / `--keep-latest-only` /
+    /// `--filter-delete-marker-only`.
+    pub async fn suspend_bucket_versioning(&self, bucket: &str) {
+        let versioning_config = VersioningConfiguration::builder()
+            .status(BucketVersioningStatus::Suspended)
+            .build();
+
+        self.client
+            .put_bucket_versioning()
+            .bucket(bucket)
+            .versioning_configuration(versioning_config)
+            .send()
+            .await
+            .unwrap_or_else(|e| panic!("Failed to suspend versioning on {bucket}: {e}"));
+    }
+
     /// Generate a unique Express One Zone directory bucket name.
     ///
     /// Format: `s3rm-e2e-{short_uuid}--{az_id}--x-s3`

--- a/tests/e2e_filter.rs
+++ b/tests/e2e_filter.rs
@@ -1900,3 +1900,299 @@ async fn e2e_filter_include_content_type_tolerates_delete_markers() {
         guard.cleanup().await;
     });
 }
+
+// ---------------------------------------------------------------------------
+// Delete markers are EXCLUDED from deletion by the size and metadata filters.
+//
+// A delete marker has no size, content type, metadata, or tags, and deleting a
+// *latest* delete marker resurrects the object it hides. So an attribute-scoped
+// --delete-all-versions run must leave delete markers in place. (The content-type
+// and tag cases are covered by e2e_filter_include_content_type_tolerates_delete_markers
+// above and e2e_delete_all_versions_tag_filter_tolerates_delete_markers in
+// e2e_versioning.rs.)
+// ---------------------------------------------------------------------------
+
+/// Delete an object via the normal API to create a delete marker on `key`.
+async fn create_delete_marker(helper: &TestHelper, bucket: &str, key: &str) {
+    helper
+        .client()
+        .delete_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("Failed to create delete marker for {key}: {e}"));
+}
+
+/// Count delete markers currently present in the bucket.
+async fn count_delete_markers(helper: &TestHelper, bucket: &str) -> usize {
+    helper
+        .list_object_versions(bucket)
+        .await
+        .iter()
+        .filter(|(k, _)| k.starts_with("[delete-marker]"))
+        .count()
+}
+
+/// Count (non-marker) object versions currently present under `key_prefix`.
+async fn count_object_versions(helper: &TestHelper, bucket: &str, key_prefix: &str) -> usize {
+    helper
+        .list_object_versions(bucket)
+        .await
+        .iter()
+        .filter(|(k, _)| !k.starts_with("[delete-marker]") && k.starts_with(key_prefix))
+        .count()
+}
+
+#[tokio::test]
+async fn e2e_filter_smaller_size_excludes_delete_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-smaller-size combined with
+        //          --delete-all-versions deletes matching small object versions
+        //          but EXCLUDES delete markers (a marker has no size and deleting
+        //          a latest marker would resurrect the object it hides).
+        // Setup:   Versioned bucket; 5 small (100B) + 5 large (10KB) objects;
+        //          delete 3 of the small keys via the normal API to create markers.
+        // Expected: Pipeline succeeds; the 5 small object versions are deleted;
+        //           the 5 large object versions remain; all 3 delete markers remain.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            helper
+                .put_object(&bucket, &format!("data/small{i}.dat"), vec![b's'; 100])
+                .await;
+        }
+        for i in 0..5 {
+            helper
+                .put_object(
+                    &bucket,
+                    &format!("data/large{i}.dat"),
+                    vec![b'L'; 10 * 1024],
+                )
+                .await;
+        }
+
+        // Create delete markers on 3 small keys. A size filter must not delete
+        // these markers.
+        for i in 0..3 {
+            create_delete_marker(&helper, &bucket, &format!("data/small{i}.dat")).await;
+        }
+
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "3 delete markers should exist before the run"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--delete-all-versions",
+            "--filter-smaller-size",
+            "1KB",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5,
+            "Only the 5 small object versions should be deleted (not the markers)"
+        );
+
+        // The delete markers must be untouched.
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "All 3 delete markers must be excluded from a size-filtered run"
+        );
+        // Large object versions remain; small object versions are gone.
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/large").await,
+            5,
+            "All large object versions should remain"
+        );
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/small").await,
+            0,
+            "All small object versions should be deleted"
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+#[tokio::test]
+async fn e2e_filter_larger_size_excludes_delete_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-larger-size combined with
+        //          --delete-all-versions deletes matching large object versions
+        //          but EXCLUDES delete markers.
+        // Setup:   Versioned bucket; 5 small (100B) + 5 large (10KB) objects;
+        //          delete 3 of the large keys via the normal API to create markers.
+        // Expected: Pipeline succeeds; the 5 large object versions are deleted;
+        //           the 5 small object versions remain; all 3 delete markers remain.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            helper
+                .put_object(&bucket, &format!("data/small{i}.dat"), vec![b's'; 100])
+                .await;
+        }
+        for i in 0..5 {
+            helper
+                .put_object(
+                    &bucket,
+                    &format!("data/large{i}.dat"),
+                    vec![b'L'; 10 * 1024],
+                )
+                .await;
+        }
+
+        // Create delete markers on 3 large keys. A size filter must not delete them.
+        for i in 0..3 {
+            create_delete_marker(&helper, &bucket, &format!("data/large{i}.dat")).await;
+        }
+
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "3 delete markers should exist before the run"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--delete-all-versions",
+            "--filter-larger-size",
+            "1KB",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5,
+            "Only the 5 large object versions should be deleted (not the markers)"
+        );
+
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "All 3 delete markers must be excluded from a size-filtered run"
+        );
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/small").await,
+            5,
+            "All small object versions should remain"
+        );
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/large").await,
+            0,
+            "All large object versions should be deleted"
+        );
+
+        guard.cleanup().await;
+    });
+}
+
+#[tokio::test]
+async fn e2e_filter_include_metadata_excludes_delete_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --filter-include-metadata-regex combined with
+        //          --delete-all-versions deletes matching object versions but
+        //          EXCLUDES delete markers. A marker has no metadata, so it is
+        //          skipped before the HeadObject call that would otherwise return
+        //          405; the run must not abort and the markers must be left in place.
+        // Setup:   Versioned bucket; 5 objects with metadata env=production and
+        //          5 with env=staging; delete 3 production keys to create markers.
+        // Expected: Pipeline succeeds; the 5 production object versions are deleted;
+        //           staging objects remain; all 3 delete markers remain.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            let mut metadata = HashMap::new();
+            metadata.insert("env".to_string(), "production".to_string());
+            helper
+                .put_object_with_metadata(
+                    &bucket,
+                    &format!("data/prod{i}.dat"),
+                    vec![b'p'; 100],
+                    metadata,
+                )
+                .await;
+        }
+        for i in 0..5 {
+            let mut metadata = HashMap::new();
+            metadata.insert("env".to_string(), "staging".to_string());
+            helper
+                .put_object_with_metadata(
+                    &bucket,
+                    &format!("data/stage{i}.dat"),
+                    vec![b'g'; 100],
+                    metadata,
+                )
+                .await;
+        }
+
+        // Create delete markers on 3 production keys — HeadObject would 405 here.
+        for i in 0..3 {
+            create_delete_marker(&helper, &bucket, &format!("data/prod{i}.dat")).await;
+        }
+
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "3 delete markers should exist before the run"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--delete-all-versions",
+            "--filter-include-metadata-regex",
+            "env=production",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(
+            !result.has_error,
+            "Delete markers must not abort a metadata-filtered --delete-all-versions run"
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5,
+            "Only the 5 production object versions should be deleted (not the markers)"
+        );
+
+        assert_eq!(
+            count_delete_markers(&helper, &bucket).await,
+            3,
+            "All 3 delete markers must be excluded from a metadata-filtered run"
+        );
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/stage").await,
+            5,
+            "All staging object versions should remain"
+        );
+        assert_eq!(
+            count_object_versions(&helper, &bucket, "data/prod").await,
+            0,
+            "All production object versions should be deleted"
+        );
+
+        guard.cleanup().await;
+    });
+}

--- a/tests/e2e_filter.rs
+++ b/tests/e2e_filter.rs
@@ -1808,3 +1808,95 @@ async fn e2e_filter_exclude_tag_regex_with_prefix() {
         guard.cleanup().await;
     });
 }
+
+// ---------------------------------------------------------------------------
+// Delete markers must not abort a content-type-filter --delete-all-versions run
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_filter_include_content_type_tolerates_delete_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --delete-all-versions combined with a content-type
+        //          filter does NOT abort when the bucket contains delete markers.
+        //          HeadObject on a delete-marker version returns HTTP 405, which
+        //          previously cancelled the whole pipeline on the first marker.
+        //          The marker must instead be evaluated against an absent
+        //          content-type (include filter → dropped) and the run succeed.
+        // Setup:   Versioned bucket; upload 5 text/plain and 5 application/json
+        //          objects; delete 3 of the text/plain keys via the normal API to
+        //          create delete markers.
+        // Expected: Pipeline succeeds (no 405 abort); the 5 text/plain object
+        //           versions are deleted; application/json objects remain.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            helper
+                .put_object_with_content_type(
+                    &bucket,
+                    &format!("data/text{i}.txt"),
+                    vec![b't'; 100],
+                    "text/plain",
+                )
+                .await;
+        }
+        for i in 0..5 {
+            helper
+                .put_object_with_content_type(
+                    &bucket,
+                    &format!("data/json{i}.json"),
+                    vec![b'j'; 100],
+                    "application/json",
+                )
+                .await;
+        }
+
+        // Create delete markers on 3 text/plain keys — HeadObject would 405 here.
+        for i in 0..3 {
+            helper
+                .client()
+                .delete_object()
+                .bucket(&bucket)
+                .key(format!("data/text{i}.txt"))
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("Failed to create delete marker: {e}"));
+        }
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--delete-all-versions",
+            "--filter-include-content-type-regex",
+            "text/plain",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        // The key assertion: the delete marker did not abort the pipeline.
+        assert!(
+            !result.has_error,
+            "Delete markers must not abort a --delete-all-versions content-type run"
+        );
+
+        // The 5 text/plain object versions match; the 3 delete markers have no
+        // content-type so the include filter drops them.
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5,
+            "Only the 5 text/plain object versions should be deleted"
+        );
+
+        // application/json objects are untouched.
+        let json_remaining = helper.list_objects(&bucket, "data/json").await;
+        assert_eq!(
+            json_remaining.len(),
+            5,
+            "All application/json objects should remain"
+        );
+
+        guard.cleanup().await;
+    });
+}

--- a/tests/e2e_keep_latest_only.rs
+++ b/tests/e2e_keep_latest_only.rs
@@ -1452,3 +1452,105 @@ async fn e2e_keep_latest_only_event_callback() {
         guard.cleanup().await;
     });
 }
+
+// ---------------------------------------------------------------------------
+// Keep Latest Only: works on a versioning-SUSPENDED bucket
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_keep_latest_only_suspended_bucket() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --keep-latest-only works on a versioning-SUSPENDED
+        //          bucket. A suspended bucket still retains all of its versions,
+        //          so it must be treated as versioned. Previously
+        //          is_versioning_enabled() returned true only for Enabled, so this
+        //          combination wrongly errored with "non-versioned bucket".
+        // Setup:   Create versioned bucket; upload 4 keys twice (8 versions); then
+        //          suspend versioning.
+        // Expected: Pipeline succeeds (no rejection); the 4 old versions are
+        //           deleted and only the 4 latest versions remain.
+
+        const NUM_OBJECTS: usize = 4;
+        const VERSIONS_PER_OBJECT: usize = 2;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        let mut old_version_ids = Vec::new();
+        for i in 0..NUM_OBJECTS {
+            let vid = put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'v'; 100],
+            )
+            .await;
+            old_version_ids.push(vid);
+        }
+        let mut latest_version_ids = Vec::new();
+        for i in 0..NUM_OBJECTS {
+            let vid = put_object_versioned(
+                &helper,
+                &bucket,
+                &format!("data/file{i}.dat"),
+                vec![b'w'; 200],
+            )
+            .await;
+            latest_version_ids.push(vid);
+        }
+
+        // Suspend versioning AFTER the versions exist. They are retained.
+        helper.suspend_bucket_versioning(&bucket).await;
+
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(
+            pre_versions.len(),
+            NUM_OBJECTS * VERSIONS_PER_OBJECT,
+            "Suspended bucket should still retain all versions"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--keep-latest-only",
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        // Regression: this must NOT be rejected as a non-versioned bucket.
+        assert!(
+            !result.has_error,
+            "--keep-latest-only must succeed on a suspended (versioned) bucket"
+        );
+        assert_eq!(
+            result.stats.stats_deleted_objects, NUM_OBJECTS as u64,
+            "Should delete {NUM_OBJECTS} old versions"
+        );
+
+        // Only the latest version of each key remains.
+        let post_versions = helper.list_object_versions(&bucket).await;
+        assert_eq!(
+            post_versions.len(),
+            NUM_OBJECTS,
+            "Only the latest version per key should remain"
+        );
+        let remaining_vids: Vec<&str> = post_versions.iter().map(|(_, vid)| vid.as_str()).collect();
+        for (i, expected_vid) in latest_version_ids.iter().enumerate() {
+            assert!(
+                remaining_vids.contains(&expected_vid.as_str()),
+                "Latest version ID for file{i}.dat ({expected_vid}) should be retained"
+            );
+        }
+        for (i, old_vid) in old_version_ids.iter().enumerate() {
+            assert!(
+                !remaining_vids.contains(&old_vid.as_str()),
+                "Old version ID for file{i}.dat ({old_vid}) should have been deleted"
+            );
+        }
+
+        guard.cleanup().await;
+    });
+}

--- a/tests/e2e_versioning.rs
+++ b/tests/e2e_versioning.rs
@@ -8,6 +8,7 @@
 mod common;
 
 use common::TestHelper;
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // 29.21 Versioned Bucket Creates Delete Markers
@@ -587,6 +588,208 @@ async fn e2e_delete_all_versions_empty_versioned_bucket() {
             "No objects to delete in empty bucket"
         );
         assert_eq!(result.stats.stats_failed_objects, 0, "No failures expected");
+
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Delete All Versions: Versioning-Suspended bucket still removes every version
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_delete_all_versions_suspended_bucket_removes_all_versions() {
+    e2e_timeout!(async {
+        // Purpose: Verify --delete-all-versions on a versioning-SUSPENDED bucket
+        //          permanently removes every retained version and delete marker,
+        //          rather than degrading to versionless deletes (which would just
+        //          add null delete markers and leave the old versions billed and
+        //          intact). A suspended bucket still holds all historical
+        //          versions, so it must be treated as versioned.
+        // Setup:   Create versioned bucket; upload 5 keys twice (10 versions);
+        //          delete 2 keys via the normal API (2 delete markers); THEN
+        //          suspend versioning. Total retained: 10 versions + 2 markers.
+        // Expected: All 12 items are permanently deleted; bucket is clean.
+        //
+        // Regression: previously is_versioning_enabled() returned true only for
+        // Enabled, so a suspended bucket silently cleared --delete-all-versions.
+
+        const NUM_OBJECTS: usize = 5;
+        const VERSIONS_PER_OBJECT: usize = 2;
+        const NUM_DELETE_MARKERS: usize = 2;
+        const EXPECTED_TOTAL_ITEMS: u64 =
+            (NUM_OBJECTS * VERSIONS_PER_OBJECT + NUM_DELETE_MARKERS) as u64;
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        // 5 keys x 2 versions each = 10 object versions.
+        for i in 0..NUM_OBJECTS {
+            helper
+                .put_object(&bucket, &format!("versioned/file{i}.dat"), vec![b'v'; 100])
+                .await;
+        }
+        for i in 0..NUM_OBJECTS {
+            helper
+                .put_object(&bucket, &format!("versioned/file{i}.dat"), vec![b'w'; 200])
+                .await;
+        }
+
+        // Delete 2 keys via the normal API to create delete markers.
+        for i in 0..NUM_DELETE_MARKERS {
+            helper
+                .client()
+                .delete_object()
+                .bucket(&bucket)
+                .key(format!("versioned/file{i}.dat"))
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("Failed to create delete marker: {e}"));
+        }
+
+        // Suspend versioning AFTER the versions/markers exist. They are retained.
+        helper.suspend_bucket_versioning(&bucket).await;
+
+        // Sanity check: the versions and markers are still present while suspended.
+        let pre_versions = helper.list_object_versions(&bucket).await;
+        let pre_real_versions = pre_versions
+            .iter()
+            .filter(|(k, _)| !k.starts_with("[delete-marker]"))
+            .count();
+        let pre_delete_markers = pre_versions
+            .iter()
+            .filter(|(k, _)| k.starts_with("[delete-marker]"))
+            .count();
+        assert_eq!(
+            pre_real_versions,
+            NUM_OBJECTS * VERSIONS_PER_OBJECT,
+            "Suspended bucket should still retain all object versions"
+        );
+        assert_eq!(
+            pre_delete_markers, NUM_DELETE_MARKERS,
+            "Suspended bucket should still retain the delete markers"
+        );
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/versioned/"),
+            "--delete-all-versions",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        assert!(!result.has_error, "Pipeline should complete without errors");
+        assert_eq!(
+            result.stats.stats_deleted_objects, EXPECTED_TOTAL_ITEMS,
+            "Should permanently delete all {EXPECTED_TOTAL_ITEMS} retained items on a suspended bucket"
+        );
+
+        // Nothing may remain — a versionless degrade would have left the 10
+        // original versions in place and only added null delete markers.
+        let versions = helper.list_object_versions(&bucket).await;
+        assert!(
+            versions.is_empty(),
+            "No versions or delete markers should remain on the suspended bucket; found {}",
+            versions.len()
+        );
+        guard.cleanup().await;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Delete All Versions + tag filter: delete markers must not abort the run
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn e2e_delete_all_versions_tag_filter_tolerates_delete_markers() {
+    e2e_timeout!(async {
+        // Purpose: Verify that --delete-all-versions combined with a tag filter
+        //          does NOT abort when the bucket contains delete markers.
+        //          GetObjectTagging on a delete-marker version returns HTTP 405,
+        //          which previously cancelled the whole pipeline on the first
+        //          marker. The marker must instead be evaluated against absent
+        //          tags (include filter → dropped) and the run must succeed.
+        // Setup:   Versioned bucket; upload 5 keys tagged status=expired and 5
+        //          tagged status=active; delete 3 of the expired keys via the
+        //          normal API to create delete markers.
+        // Expected: Pipeline succeeds (no 405 abort); the current (non-marker)
+        //           expired versions are deleted; active objects remain.
+
+        let helper = TestHelper::new().await;
+        let bucket = helper.generate_bucket_name();
+        helper.create_versioned_bucket(&bucket).await;
+
+        let guard = helper.bucket_guard(&bucket);
+
+        for i in 0..5 {
+            let mut tags = HashMap::new();
+            tags.insert("status".to_string(), "expired".to_string());
+            helper
+                .put_object_with_tags(
+                    &bucket,
+                    &format!("data/expired{i}.dat"),
+                    vec![b'e'; 100],
+                    tags,
+                )
+                .await;
+        }
+        for i in 0..5 {
+            let mut tags = HashMap::new();
+            tags.insert("status".to_string(), "active".to_string());
+            helper
+                .put_object_with_tags(
+                    &bucket,
+                    &format!("data/active{i}.dat"),
+                    vec![b'a'; 100],
+                    tags,
+                )
+                .await;
+        }
+
+        // Create delete markers on 3 expired keys (these are the versions that
+        // GetObjectTagging would 405 on).
+        for i in 0..3 {
+            helper
+                .client()
+                .delete_object()
+                .bucket(&bucket)
+                .key(format!("data/expired{i}.dat"))
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("Failed to create delete marker: {e}"));
+        }
+
+        let config = TestHelper::build_config(vec![
+            &format!("s3://{bucket}/data/"),
+            "--delete-all-versions",
+            "--filter-include-tag-regex",
+            "status=expired",
+            "--force",
+        ]);
+        let result = TestHelper::run_pipeline(config).await;
+
+        // The key assertion: the delete marker did not abort the pipeline.
+        assert!(
+            !result.has_error,
+            "Delete markers must not abort a --delete-all-versions tag-filter run"
+        );
+
+        // The 5 expired object versions match the include filter and are deleted;
+        // the 3 delete markers have no tags so the include filter drops them.
+        assert_eq!(
+            result.stats.stats_deleted_objects, 5,
+            "Only the 5 tagged expired object versions should be deleted"
+        );
+
+        // Active objects are untouched.
+        let active_remaining = helper.list_objects(&bucket, "data/active").await;
+        assert_eq!(
+            active_remaining.len(),
+            5,
+            "All active objects should remain"
+        );
 
         guard.cleanup().await;
     });


### PR DESCRIPTION
**Contributing**

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `--delete-all-versions` correctly handles S3 buckets with suspended versioning.
  - Suspended buckets no longer break `--keep-latest-only`.
  - Delete markers no longer abort runs when filtered; delete markers are properly excluded by size/content-type/metadata/tag filtering, and modification-time/key-regex filtering still applies.
  - `--filter-delete-marker-only` is now documented as conflicting with size/content-type/metadata/tag filters.

- **Documentation**
  - Updated changelog and README filtering-order guidance, plus added security assumptions.

- **Maintenance**
  - Bumped the release version to **1.3.9**.
  - Improved CLI help text and hid credential values from CLI output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->