### PR TITLE
Remove TARGET env var binding from positional target argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-25
+
+### Changed
+
+- [Breaking change] The positional target argument no longer reads its value from the TARGET environment variable. This
+  generic variable name could unintentionally override the command line arguments
+
 ## [1.4.0] - 2026-07-20
 
 Monthly update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2661,7 +2661,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/src/config/args/mod.rs
+++ b/src/config/args/mod.rs
@@ -109,7 +109,6 @@ fn parse_human_bytes(s: &str) -> Result<u64, String> {
 pub struct CLIArgs {
     /// S3 target path: s3://<BUCKET_NAME>[/prefix]
     #[arg(
-        env,
         help = "s3://<BUCKET_NAME>[/prefix]",
         value_parser = check_s3_target,
         default_value_if("auto_complete_shell", clap::builder::ArgPredicate::IsPresent, "s3://ignored"),

--- a/src/config/args/tests.rs
+++ b/src/config/args/tests.rs
@@ -19,6 +19,22 @@ fn parse_minimal_args() {
 }
 
 #[test]
+fn positional_target_has_no_env_binding() {
+    init_dummy_tracing_subscriber();
+
+    use clap::CommandFactory;
+    let command = CLIArgs::command();
+    let target = command
+        .get_arguments()
+        .find(|arg| arg.get_id() == "target")
+        .unwrap();
+    assert!(
+        target.get_env().is_none(),
+        "the positional target argument must not read the TARGET environment variable"
+    );
+}
+
+#[test]
 fn parse_dry_run_long() {
     let args = vec!["s3rm", "s3://bucket/", "--dry-run"];
     let cli = parse_from_args(args).unwrap();


### PR DESCRIPTION
[Breaking change] The positional target argument no longer reads its value from the TARGET environment variable. This generic variable name could unintentionally override the command line arguments.

Add a regression test asserting the positional has no env binding, and release v1.5.0.

**Contributing**

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.
