### PR TITLE
Fix broken pipe panics when output pipes are closed early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.2] - 2026-08-02
+
+### Fixed
+
+- Generating shell completions into a closed pipe (`s3rm --auto-complete-shell bash | head 1`) panicked inside
+  clap_complete with `failed to write completion file: ... Broken pipe`. `head` treats `1` as a file name, fails to
+  open it, and exits without reading its input at all, so the pipe is already closed when s3rm prints the script —
+  and any consumer that stops reading before the output ends does the same (`head -1` when the output is larger than
+  the pipe buffer, `grep -q`, a pager closed early). The completion script is now rendered to an in-memory buffer and
+  written pipe-safely: a closed pipe is treated as the normal end of a pipeline and the command exits 0 — note that
+  under `set -o pipefail` such pipelines now succeed where the panic previously failed them. Any other stdout write
+  failure (e.g. disk full on a redirect) now exits 1 with an error message instead of panicking.
+- The blank spacing line printed to stderr after the final deletion summary panicked when stderr was a closed pipe
+  (e.g. `s3rm -f ... 2>&1 | head -1`): the deletion itself had already completed, but the process died with exit
+  code 101 (abnormal termination) instead of reporting the pipeline result. The `Deletion cancelled.` notice and the
+  example `UserDefinedEventCallback` event lines had the same defect. All of them are now written best-effort,
+  matching the tracing output, which already ignored a closed stderr.
+
 ## [1.5.1] - 2026-07-26
 
 Dependency update.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.5.1"
+version = "1.5.2"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/src/bin/s3rm/indicator.rs
+++ b/src/bin/s3rm/indicator.rs
@@ -134,7 +134,10 @@ pub fn show_indicator(
                             HumanDuration(elapsed),
                         ));
 
-                        eprintln!();
+                        // eprintln! panics when stderr is a closed pipe
+                        // (`s3rm ... 2>&1 | head`); the summary spacing
+                        // line is best-effort, like the flush below.
+                        let _ = writeln!(io::stderr());
                         let _ = io::stderr().flush();
                     }
 

--- a/src/bin/s3rm/main.rs
+++ b/src/bin/s3rm/main.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use anyhow::Result;
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
@@ -16,6 +18,7 @@ mod ctrl_c_handler;
 pub mod indicator;
 #[cfg(test)]
 mod indicator_properties;
+mod pipe_safe;
 mod tracing_init;
 pub mod ui_config;
 
@@ -31,14 +34,7 @@ async fn main() -> Result<()> {
     let config = load_config_exit_if_err();
 
     if let Some(shell) = config.auto_complete_shell {
-        generate(
-            shell,
-            &mut CLIArgs::command(),
-            "s3rm",
-            &mut std::io::stdout(),
-        );
-
-        return Ok(());
+        return print_completion_script(shell);
     }
 
     start_tracing_if_necessary(&config);
@@ -53,6 +49,30 @@ fn load_config_exit_if_err() -> Config {
         Ok(config) => config,
         Err(error_message) => {
             clap::Error::raw(clap::error::ErrorKind::ValueValidation, error_message).exit();
+        }
+    }
+}
+
+/// Render the shell-completion script for `shell` and print it pipe-safely.
+///
+/// clap_complete's generators panic on writer errors ("failed to write
+/// completion file"), so they never touch stdout directly: the script is
+/// rendered into an infallible in-memory buffer and written in one
+/// pipe-safe pass. A reader that exits early
+/// (`s3rm --auto-complete-shell bash | head`) yields exit 0; any other
+/// stdout write error is reported on stderr with exit 1.
+fn print_completion_script(shell: clap_complete::shells::Shell) -> Result<()> {
+    let mut script = Vec::new();
+    generate(shell, &mut CLIArgs::command(), "s3rm", &mut script);
+    match pipe_safe::write_all_pipe_safe(&script) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // Tracing is never initialized on this path; best-effort stderr.
+            let _ = writeln!(
+                std::io::stderr(),
+                "error: failed to write completion script: {e}"
+            );
+            std::process::exit(1);
         }
     }
 }
@@ -121,7 +141,11 @@ async fn run(mut config: Config) -> Result<()> {
         if let Err(e) = pipeline.check_prerequisites().await {
             pipeline.close_stats_sender();
             if is_cancelled_error(&e) {
-                eprintln!("Deletion cancelled.");
+                // eprintln! panics when stderr is a closed pipe; the
+                // cancellation notice is best-effort, like the tracing
+                // output (PipeSafeWriter), which already ignores a
+                // closed stderr.
+                let _ = writeln!(std::io::stderr(), "Deletion cancelled.");
                 debug!("deletion cancelled by user.");
                 return Ok(());
             }

--- a/src/bin/s3rm/pipe_safe.rs
+++ b/src/bin/s3rm/pipe_safe.rs
@@ -1,0 +1,115 @@
+//! Pipe-safe stdout printing.
+//!
+//! Stdout writes panic (or, inside clap_complete, `panic!` explicitly) when
+//! stdout is a pipe whose reader has already gone away — piping to a
+//! `head`/`grep -q`/pager that exited before the output ended, or
+//! `s3rm --auto-complete-shell bash | head 1`, where `head` fails to open
+//! the file `1` and never reads its input at all. The only stdout output
+//! s3rm produces is the shell-completion script, and it goes through this
+//! helper instead: `BrokenPipe` is swallowed — a reader that stops early is
+//! a normal way for a pipeline to end — so the command still exits 0. Any
+//! other write error (full disk or I/O error on a redirect) is propagated
+//! so the command fails loudly instead of silently dropping output.
+//!
+//! The stderr counterpart for tracing output is
+//! `tracing_init::PipeSafeWriter`. The confirmation prompt intentionally
+//! keeps its strict `println!` writes: it is only reachable when stdout is
+//! a TTY (`SafetyChecker` errors out in non-interactive environments), and
+//! a TTY cannot produce `BrokenPipe`.
+
+use std::io::{ErrorKind, Write};
+
+/// Write `bytes` to stdout as-is (no trailing newline), swallowing
+/// BrokenPipe. Used for pre-rendered output such as shell-completion
+/// scripts.
+pub fn write_all_pipe_safe(bytes: &[u8]) -> std::io::Result<()> {
+    write_all_ignoring_broken_pipe(&mut std::io::stdout().lock(), bytes)
+}
+
+fn write_all_ignoring_broken_pipe(writer: &mut impl Write, bytes: &[u8]) -> std::io::Result<()> {
+    ignore_broken_pipe(writer.write_all(bytes).and_then(|()| writer.flush()))
+}
+
+fn ignore_broken_pipe(result: std::io::Result<()>) -> std::io::Result<()> {
+    match result {
+        Err(e) if e.kind() == ErrorKind::BrokenPipe => Ok(()),
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fails writes (or, with `fail_flush`, only the flush) with `kind`.
+    /// The real closed-pipe scenario is exercised process-level by
+    /// `tests/cli_broken_pipe.rs`.
+    struct FailWriter {
+        kind: ErrorKind,
+        fail_flush: bool,
+    }
+
+    impl Write for FailWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            if self.fail_flush {
+                Ok(buf.len())
+            } else {
+                Err(std::io::Error::new(self.kind, "simulated write failure"))
+            }
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            if self.fail_flush {
+                Err(std::io::Error::new(self.kind, "simulated flush failure"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn write_all_passes_bytes_through_verbatim() {
+        let mut buf = Vec::new();
+        write_all_ignoring_broken_pipe(&mut buf, b"complete -c s3rm\n").unwrap();
+        assert_eq!(buf, b"complete -c s3rm\n");
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_write() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: false,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_swallows_broken_pipe_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::BrokenPipe,
+            fail_flush: true,
+        };
+        write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap();
+    }
+
+    #[test]
+    fn write_all_propagates_other_errors() {
+        // A failed redirect (disk full, I/O error) must still fail the
+        // command — only a vanished reader is benign.
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: false,
+        };
+        let err = write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+
+    #[test]
+    fn write_all_propagates_other_errors_on_flush() {
+        let mut writer = FailWriter {
+            kind: ErrorKind::StorageFull,
+            fail_flush: true,
+        };
+        let err = write_all_ignoring_broken_pipe(&mut writer, b"data").unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::StorageFull);
+    }
+}

--- a/src/callback/user_defined_event_callback.rs
+++ b/src/callback/user_defined_event_callback.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::types::event_callback::{EventCallback, EventData, EventType};
 use async_trait::async_trait;
 
@@ -27,34 +29,37 @@ impl EventCallback for UserDefinedEventCallback {
     // If a callback function takes a long time to execute, it may block a whole pipeline.
     async fn on_event(&mut self, event_data: EventData) {
         // Todo: Implement your custom event handling logic here.
+        // eprintln! panics when stderr is a closed pipe (`s3rm ... 2>&1 |
+        // head`); event reporting is best-effort, like the tracing output,
+        // which already ignores a closed stderr.
         match event_data.event_type {
             EventType::PIPELINE_START => {
-                eprintln!("Pipeline started: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Pipeline started: {event_data:?}");
             }
             EventType::PIPELINE_END => {
-                eprintln!("Pipeline ended: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Pipeline ended: {event_data:?}");
             }
             EventType::DELETE_COMPLETE => {
-                eprintln!("Delete complete: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Delete complete: {event_data:?}");
             }
             EventType::DELETE_FAILED => {
-                eprintln!("Delete failed: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Delete failed: {event_data:?}");
             }
             EventType::DELETE_FILTERED => {
-                eprintln!("Delete filtered: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Delete filtered: {event_data:?}");
             }
             EventType::PIPELINE_ERROR => {
-                eprintln!("Pipeline error: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Pipeline error: {event_data:?}");
             }
             EventType::DELETE_CANCEL => {
-                eprintln!("Delete cancelled: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Delete cancelled: {event_data:?}");
             }
             EventType::STATS_REPORT => {
-                eprintln!("Stats report: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Stats report: {event_data:?}");
             }
             // Currently, all events are captured by above match arms,
             _ => {
-                eprintln!("Other events: {event_data:?}");
+                let _ = writeln!(std::io::stderr(), "Other events: {event_data:?}");
             }
         }
     }

--- a/tests/cli_broken_pipe.rs
+++ b/tests/cli_broken_pipe.rs
@@ -1,0 +1,141 @@
+//! Process-level broken-pipe regression tests. Like `cli_exit_codes.rs`,
+//! these never touch AWS: completions, help, and version never leave the
+//! process, and the pipeline test fails during listing against an
+//! unreachable endpoint.
+//!
+//! Each test hands the child a stdout (or stderr) whose read end is already
+//! closed, so every write to it fails with `BrokenPipe` from the first byte —
+//! the worst case of piping to a consumer that exits without reading, such as
+//! `s3rm --auto-complete-shell bash | head 1` (`head` treats `1` as a file
+//! name, fails to open it, and never reads its input) or `head -1`/`grep -q`/
+//! a pager closed early. The binary must exit through its normal paths: never
+//! panic ("failed printing to stdout: Broken pipe") and never die of SIGPIPE
+//! (which would surface here as `status.code() == None`).
+
+use std::process::{Command, Stdio};
+
+fn s3rm() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_s3rm"))
+}
+
+/// Run `cmd` with a pre-closed stdout pipe and return (exit_code, stderr).
+fn run_with_closed_stdout(cmd: &mut Command) -> (Option<i32>, String) {
+    let (reader, writer) = std::io::pipe().expect("failed to create pipe");
+    // Close the read end before the child even starts: with no readers left,
+    // every stdout write in the child fails with EPIPE immediately.
+    drop(reader);
+
+    let output = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn s3rm binary");
+    (
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr).to_string(),
+    )
+}
+
+/// Run `cmd` with pre-closed stdout AND stderr pipes; only the exit code is
+/// observable. This is the `s3rm ... 2>&1 | head 1` case, where both streams
+/// share one pipe whose reader is already gone.
+fn run_with_closed_stdout_and_stderr(cmd: &mut Command) -> Option<i32> {
+    let (out_reader, out_writer) = std::io::pipe().expect("failed to create pipe");
+    let (err_reader, err_writer) = std::io::pipe().expect("failed to create pipe");
+    drop(out_reader);
+    drop(err_reader);
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::from(out_writer))
+        .stderr(Stdio::from(err_writer))
+        .status()
+        .expect("failed to spawn s3rm binary")
+        .code()
+}
+
+fn assert_exits_zero_without_panic(code: Option<i32>, stderr: &str, what: &str) {
+    assert!(
+        !stderr.contains("panicked"),
+        "{what} must not panic on a closed stdout pipe; stderr: {stderr}"
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "{what} must exit 0 on a closed stdout pipe (None = killed by \
+         SIGPIPE); stderr: {stderr}"
+    );
+}
+
+/// Completion scripts are rendered to a buffer and written pipe-safely —
+/// clap_complete itself would panic ("failed to write completion file") if
+/// its generator wrote straight into a closed stdout.
+#[test]
+fn completion_script_with_closed_stdout_exits_zero() {
+    for shell in ["bash", "zsh", "fish"] {
+        let (code, stderr) = run_with_closed_stdout(s3rm().args(["--auto-complete-shell", shell]));
+        assert_exits_zero_without_panic(code, &stderr, &format!("--auto-complete-shell {shell}"));
+    }
+}
+
+/// `--help` and `--version` are printed by clap, whose `Error::exit`
+/// swallows write errors ("Swallow broken pipe errors" in clap itself).
+/// Pinned here so a clap regression would be caught.
+#[test]
+fn help_and_version_with_closed_stdout_exit_zero() {
+    let (code, stderr) = run_with_closed_stdout(s3rm().arg("--help"));
+    assert_exits_zero_without_panic(code, &stderr, "--help");
+
+    let (code, stderr) = run_with_closed_stdout(s3rm().arg("--version"));
+    assert_exits_zero_without_panic(code, &stderr, "--version");
+}
+
+/// Config errors are reported via `clap::Error::raw(...).exit()`, which also
+/// swallows a closed stderr: the exit code must stay 2 (InvalidConfig), not
+/// become a panic or SIGPIPE death.
+#[test]
+fn config_error_with_closed_stderr_still_exits_two() {
+    let code = run_with_closed_stdout_and_stderr(s3rm().arg("s3:///prefix"));
+    assert_eq!(
+        code,
+        Some(2),
+        "an invalid target with closed output pipes must still exit 2 \
+         (None = killed by SIGPIPE, 101 = panicked)"
+    );
+}
+
+/// The final deletion summary writes a spacing line to stderr after the
+/// indicatif message. With stderr a closed pipe that `eprintln!()` panicked
+/// inside the indicator task, and `main` turned the join error into exit 101
+/// (abnormal termination) — even though the pipeline itself had already
+/// finished. Now the summary lines are best-effort: the process must exit
+/// through the normal error path (exit 1, from the listing failure against
+/// the unreachable endpoint), like `cli_exit_codes.rs` pins for open pipes.
+#[test]
+fn deletion_summary_with_closed_stderr_exits_through_normal_error_path() {
+    let code = run_with_closed_stdout_and_stderr(
+        s3rm()
+            .arg("--dry-run")
+            .arg("--aws-config-file")
+            .arg("./test_data/test_config/config")
+            .arg("--aws-shared-credentials-file")
+            .arg("./test_data/test_config/credentials")
+            .arg("--target-access-key")
+            .arg("dummy")
+            .arg("--target-secret-access-key")
+            .arg("dummy")
+            .arg("--target-endpoint-url")
+            .arg("https://anything.invalid")
+            .arg("--connect-timeout-milliseconds")
+            .arg("1")
+            .arg("--aws-max-attempts")
+            .arg("0")
+            .arg("s3://test-bucket/prefix/"),
+    );
+    assert_eq!(
+        code,
+        Some(1),
+        "a listing failure with closed output pipes must exit 1 \
+         (101 = the summary line panicked, None = killed by SIGPIPE)"
+    );
+}


### PR DESCRIPTION
Piping s3rm output to a consumer that exits without reading it (`s3rm --auto-complete-shell bash | head 1`, `2>&1 | head -1`) panicked:

- Shell-completion generation panicked inside clap_complete ("failed to write completion file"). The script is now rendered to an in-memory buffer and written pipe-safely: a closed pipe is the normal end of a pipeline and exits 0, any other stdout write error is reported on stderr with exit 1.
- The blank spacing line after the final deletion summary, the "Deletion cancelled." notice, and the example UserDefinedEventCallback event lines panicked on a closed stderr (exit 101 even though the deletion had already completed). They are now written best-effort, matching the tracing output, which already ignored a closed stderr.

Adds process-level regression tests (tests/cli_broken_pipe.rs) that run the binary with pre-closed stdout/stderr pipes; no AWS access needed. They also pin the clap-owned paths (--help, --version, config errors), which already swallow BrokenPipe themselves.

**Contributing**

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line behavior when output is piped to a process that closes the pipe.
  * Shell completion, help, and version commands now exit cleanly instead of panicking or terminating unexpectedly.
  * Other output failures are reported appropriately with a nonzero exit status.
  * Status and event messages no longer fail when stderr is unavailable.

* **Documentation**
  * Updated the changelog with these fixes.

* **Release**
  * Published version 1.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->