### PR TITLE
Exit with code 130 when a deletion is interrupted by Ctrl+C (SIGINT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-08-06
+
+### Fixed
+
+- [Breaking change] A deletion interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional
+  shell encoding for termination by signal) instead of 0. Previously an interrupted deletion was indistinguishable
+  from a successful one by its exit code; scripts that test the exit status should treat 130 as user interruption
+  rather than success.
+
 ## [1.5.2] - 2026-08-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.5.2"
+version = "1.6.0"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ An event callback Lua script does not stop the operation — just shows a warnin
 - 2: Invalid arguments
 - 3: Exit with warning (partial failure; use `--warn-as-error` to treat as error)
 - 101: Abnormal termination (internal panic)
+- 130: Interrupted by Ctrl+C (SIGINT; 128 + signal number, the conventional shell encoding)
 
 ## Advanced options
 

--- a/src/bin/s3rm/ctrl_c_handler/mod.rs
+++ b/src/bin/s3rm/ctrl_c_handler/mod.rs
@@ -2,10 +2,23 @@
 //
 // Uses tokio::select! to wait for either pipeline cancellation or Ctrl+C signal.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use s3rm_rs::PipelineCancellationToken;
 use tokio::task::JoinHandle;
 use tokio::{select, signal};
 use tracing::{debug, error};
+
+static CTRL_C_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Whether a Ctrl+C (SIGINT) signal has been received by the handler.
+///
+/// The flag is stored before the cancellation token is cancelled, so any
+/// code that observes the pipeline stopping due to cancellation is
+/// guaranteed to see `true` here when Ctrl+C was the cause.
+pub fn is_ctrl_c_received() -> bool {
+    CTRL_C_RECEIVED.load(Ordering::SeqCst)
+}
 
 pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -17,6 +30,7 @@ pub fn spawn_ctrl_c_handler(cancellation_token: PipelineCancellationToken) -> Jo
                 match result {
                     Ok(()) => {
                         debug!("ctrl-c received, shutting down.");
+                        CTRL_C_RECEIVED.store(true, Ordering::SeqCst);
                         cancellation_token.cancel();
                     }
                     Err(e) => {
@@ -77,6 +91,87 @@ mod tests {
         join_handle.await.unwrap();
 
         assert!(cancellation_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_set_on_sigint() {
+        const WAITING_TIME_MILLIS_FOR_ASYNC_CTRL_C_HANDLER_START: u64 = 100;
+
+        init_dummy_tracing_subscriber();
+
+        let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(
+            WAITING_TIME_MILLIS_FOR_ASYNC_CTRL_C_HANDLER_START,
+        ))
+        .await;
+
+        assert!(!is_ctrl_c_received());
+
+        kill_sigint_to_self();
+
+        join_handle.await.unwrap();
+
+        assert!(is_ctrl_c_received());
+        assert!(cancellation_token.is_cancelled());
+    }
+
+    /// The flag must already be visible when the token cancellation becomes
+    /// observable — main.rs relies on this ordering to decide the exit code
+    /// after the pipeline stops.
+    #[tokio::test]
+    #[cfg(target_family = "unix")]
+    async fn ctrl_c_received_flag_is_visible_once_token_is_cancelled() {
+        const WAITING_TIME_MILLIS_FOR_ASYNC_CTRL_C_HANDLER_START: u64 = 100;
+
+        init_dummy_tracing_subscriber();
+
+        let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        tokio::time::sleep(std::time::Duration::from_millis(
+            WAITING_TIME_MILLIS_FOR_ASYNC_CTRL_C_HANDLER_START,
+        ))
+        .await;
+
+        kill_sigint_to_self();
+
+        cancellation_token.cancelled().await;
+        assert!(is_ctrl_c_received());
+
+        join_handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ctrl_c_received_flag_is_not_set_on_token_cancellation() {
+        init_dummy_tracing_subscriber();
+
+        let _semaphore = SEMAPHORE.clone().acquire_owned().await.unwrap();
+        reset_ctrl_c_received();
+
+        let cancellation_token = create_pipeline_cancellation_token();
+
+        let join_handle = spawn_ctrl_c_handler(cancellation_token.clone());
+        cancellation_token.cancel();
+
+        join_handle.await.unwrap();
+
+        assert!(!is_ctrl_c_received());
+    }
+
+    /// The flag is process-global; tests that assert on it reset it first
+    /// (while holding SEMAPHORE) so they don't observe a SIGINT from an
+    /// earlier test.
+    fn reset_ctrl_c_received() {
+        CTRL_C_RECEIVED.store(false, Ordering::SeqCst);
     }
 
     #[cfg(target_family = "unix")]

--- a/src/bin/s3rm/main.rs
+++ b/src/bin/s3rm/main.rs
@@ -24,6 +24,10 @@ pub mod ui_config;
 
 const EXIT_CODE_WARNING: i32 = 3;
 const EXIT_CODE_ABNORMAL_TERMINATION: i32 = 101;
+/// Conventional exit code for termination by Ctrl+C: 128 + SIGINT(2), the
+/// shell encoding that lets scripts distinguish user interruption from
+/// real failures.
+const SIGINT_EXIT_CODE: i32 = 130;
 
 /// s3rm - Fast Amazon S3 object deletion tool.
 ///
@@ -176,6 +180,14 @@ async fn run(mut config: Config) -> Result<()> {
 
         let duration_sec = format!("{:.3}", start_time.elapsed().as_secs_f32());
 
+        // Ctrl+C takes precedence over whatever the pipeline recorded: once
+        // SIGINT is received the run is "interrupted", even if the forced
+        // shutdown also surfaced errors or warnings.
+        if ctrl_c_handler::is_ctrl_c_received() {
+            debug!(duration_sec = duration_sec, "deletion cancelled by user.");
+            std::process::exit(SIGINT_EXIT_CODE);
+        }
+
         if pipeline.has_error() {
             if pipeline.has_panic() {
                 error!(duration_sec = duration_sec, "s3rm abnormal termination.");
@@ -290,6 +302,24 @@ mod tests {
         assert!(
             !config.filter_manager.is_callback_registered(),
             "Filter callback should NOT be registered by default"
+        );
+    }
+
+    // ===================================================================
+    // SIGINT exit code tests
+    // ===================================================================
+
+    #[test]
+    fn sigint_exit_code_is_130() {
+        assert_eq!(SIGINT_EXIT_CODE, 130);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn sigint_exit_code_follows_128_plus_signal_number_convention() {
+        assert_eq!(
+            SIGINT_EXIT_CODE,
+            128 + nix::sys::signal::Signal::SIGINT as i32
         );
     }
 

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -300,6 +300,7 @@ fn spawn_s3rm(endpoint: &str, extra_args: &[&str]) -> Child {
 /// counted by `counter`, so the child is provably inside the pipeline (its
 /// Ctrl+C handler is installed before the pipeline starts, thus long since
 /// registered). Fails fast with the child's stderr if it exits early.
+#[cfg(target_family = "unix")]
 fn wait_for_count(child: &mut Child, counter: &AtomicUsize, at_least: usize, what: &str) {
     let deadline = Instant::now() + Duration::from_secs(30);
     while counter.load(Ordering::SeqCst) < at_least {

--- a/tests/cli_sigint_exit_code.rs
+++ b/tests/cli_sigint_exit_code.rs
@@ -1,0 +1,518 @@
+//! Process-level regression tests for SIGINT (Ctrl+C) exit-code handling.
+//!
+//! `s3rm` catches Ctrl+C, cancels the deletion pipeline, and must then exit
+//! gracefully with code 130 (128 + SIGINT), the conventional shell encoding
+//! for a run interrupted by the user. These tests run the real binary
+//! against a minimal in-process S3 endpoint (no AWS access needed): the
+//! endpoint keeps returning truncated list pages so the deletion runs until
+//! the test sends SIGINT, and answers batch (`DeleteObjects`) and
+//! single-object (`DeleteObject`) delete requests so the deletion stages
+//! stay active as well.
+//!
+//! Covers `src/bin/s3rm/main.rs` (`is_ctrl_c_received` → exit
+//! `SIGINT_EXIT_CODE`) and `src/bin/s3rm/ctrl_c_handler/mod.rs`.
+
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Which listing API the fake endpoint emulates.
+#[derive(Clone, Copy)]
+enum ListingKind {
+    Objects,
+    #[cfg(target_family = "unix")]
+    Versions,
+}
+
+/// Handle to a fake S3 endpoint running on a background thread.
+struct FakeS3 {
+    endpoint: String,
+    pages_served: Arc<AtomicUsize>,
+    deletes_served: Arc<AtomicUsize>,
+    deleted_keys: Arc<Mutex<Vec<String>>>,
+}
+
+/// Serve canned S3 responses over plain HTTP/1.1, one request per
+/// connection, serialized by the accept loop:
+///
+/// - `GET ?versioning` → versioning enabled (for `--delete-all-versions`)
+/// - `GET` (list) → one page with one object, advancing its continuation
+///   token / key marker each time. With `total_pages = Some(n)` the n-th
+///   page is final (`IsTruncated` false); with `None` the listing is
+///   endless, so the child only stops when it is signalled.
+/// - `POST ?delete` (batch `DeleteObjects`) → echo every requested key
+///   (and version id) back as `<Deleted>`
+/// - `DELETE` (single `DeleteObject`) → 204 No Content
+fn spawn_fake_s3(kind: ListingKind, total_pages: Option<usize>) -> FakeS3 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("failed to bind fake S3 listener");
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let pages_served = Arc::new(AtomicUsize::new(0));
+    let deletes_served = Arc::new(AtomicUsize::new(0));
+    let deleted_keys = Arc::new(Mutex::new(Vec::new()));
+
+    let pages = Arc::clone(&pages_served);
+    let deletes = Arc::clone(&deletes_served);
+    let keys = Arc::clone(&deleted_keys);
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
+            let Some((request_line, request_body)) = read_request(&mut stream) else {
+                continue;
+            };
+
+            let (status_line, body) = route_request(
+                &request_line,
+                &request_body,
+                kind,
+                total_pages,
+                &pages,
+                &deletes,
+                &keys,
+            );
+            let response = format!(
+                "HTTP/1.1 {status_line}\r\ncontent-type: application/xml\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    FakeS3 {
+        endpoint,
+        pages_served,
+        deletes_served,
+        deleted_keys,
+    }
+}
+
+/// Read one HTTP request (head plus `content-length` body) and return its
+/// request line and body.
+fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
+    let mut data = Vec::new();
+    let mut buf = [0u8; 4096];
+    let header_end = loop {
+        match stream.read(&mut buf) {
+            Ok(0) => return None,
+            Ok(n) => {
+                data.extend_from_slice(&buf[..n]);
+                if let Some(pos) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break pos + 4;
+                }
+            }
+            Err(_) => return None,
+        }
+    };
+
+    let head = String::from_utf8_lossy(&data[..header_end]).to_string();
+    let request_line = head.lines().next().unwrap_or("").to_string();
+
+    let mut content_length = 0usize;
+    for line in head.lines().skip(1) {
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("content-length")
+        {
+            content_length = value.trim().parse().unwrap_or(0);
+        }
+    }
+    while data.len() - header_end < content_length {
+        match stream.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => data.extend_from_slice(&buf[..n]),
+            Err(_) => break,
+        }
+    }
+
+    let body = String::from_utf8_lossy(&data[header_end..]).to_string();
+    Some((request_line, body))
+}
+
+fn route_request(
+    request_line: &str,
+    request_body: &str,
+    kind: ListingKind,
+    total_pages: Option<usize>,
+    pages_served: &AtomicUsize,
+    deletes_served: &AtomicUsize,
+    deleted_keys: &Mutex<Vec<String>>,
+) -> (&'static str, String) {
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let target = parts.next().unwrap_or("");
+
+    match method {
+        // GetBucketVersioning, used by the --delete-all-versions
+        // prerequisite check. Must not be confused with the `versions`
+        // (ListObjectVersions) query parameter.
+        "GET" if has_query_param(target, "versioning") => ("200 OK", versioning_enabled_page()),
+        "GET" => {
+            let page = pages_served.fetch_add(1, Ordering::SeqCst);
+            let truncated = total_pages.is_none_or(|total| page + 1 < total);
+            let body = match kind {
+                ListingKind::Objects => objects_page(page, truncated),
+                #[cfg(target_family = "unix")]
+                ListingKind::Versions => versions_page(page, truncated),
+            };
+            ("200 OK", body)
+        }
+        // Batch DeleteObjects: acknowledge every requested key as deleted.
+        "POST" if has_query_param(target, "delete") => {
+            let requested = parse_delete_request(request_body);
+            {
+                let mut recorded = deleted_keys.lock().unwrap();
+                recorded.extend(requested.iter().map(|(key, _)| key.clone()));
+            }
+            deletes_served.fetch_add(1, Ordering::SeqCst);
+            ("200 OK", delete_result_page(&requested))
+        }
+        // Single-object DeleteObject.
+        "DELETE" => {
+            let path = target.split('?').next().unwrap_or("");
+            let key = path.rsplit('/').next().unwrap_or("").to_string();
+            deleted_keys.lock().unwrap().push(key);
+            deletes_served.fetch_add(1, Ordering::SeqCst);
+            ("204 No Content", String::new())
+        }
+        _ => ("400 Bad Request", String::new()),
+    }
+}
+
+/// Whether the request target carries the query parameter `name`
+/// (`?versioning` matches `versioning` but not `versions`).
+fn has_query_param(target: &str, name: &str) -> bool {
+    target
+        .split_once('?')
+        .map(|(_, query)| {
+            query
+                .split('&')
+                .any(|param| param.split('=').next() == Some(name))
+        })
+        .unwrap_or(false)
+}
+
+/// Extract the `(key, version_id)` pairs from a `DeleteObjects` request body.
+fn parse_delete_request(body: &str) -> Vec<(String, Option<String>)> {
+    body.split("<Object>")
+        .skip(1)
+        .map(|chunk| {
+            let object = chunk.split("</Object>").next().unwrap_or(chunk);
+            (
+                extract_tag(object, "Key").unwrap_or_default(),
+                extract_tag(object, "VersionId"),
+            )
+        })
+        .collect()
+}
+
+fn extract_tag(xml: &str, tag: &str) -> Option<String> {
+    let open = format!("<{tag}>");
+    let close = format!("</{tag}>");
+    let start = xml.find(&open)? + open.len();
+    let end = xml[start..].find(&close)? + start;
+    Some(xml[start..end].to_string())
+}
+
+fn versioning_enabled_page() -> String {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>"#
+        .to_string()
+}
+
+fn objects_page(page: usize, truncated: bool) -> String {
+    let next_token = if truncated {
+        format!("<NextContinuationToken>token-{page}</NextContinuationToken>")
+    } else {
+        String::new()
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>fake-sigint-bucket</Name><Prefix></Prefix><KeyCount>1</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>{truncated}</IsTruncated>{next_token}<Contents><Key>page-{page}.txt</Key><LastModified>2026-01-01T00:00:00.000Z</LastModified><ETag>&quot;0123456789abcdef0123456789abcdef&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>"#
+    )
+}
+
+#[cfg(target_family = "unix")]
+fn versions_page(page: usize, truncated: bool) -> String {
+    let next_markers = if truncated {
+        format!(
+            "<NextKeyMarker>page-{page}.txt</NextKeyMarker><NextVersionIdMarker>version-{page}</NextVersionIdMarker>"
+        )
+    } else {
+        String::new()
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>fake-sigint-bucket</Name><Prefix></Prefix><KeyMarker></KeyMarker><VersionIdMarker></VersionIdMarker><MaxKeys>1000</MaxKeys><IsTruncated>{truncated}</IsTruncated>{next_markers}<Version><Key>page-{page}.txt</Key><VersionId>version-{page}</VersionId><IsLatest>true</IsLatest><LastModified>2026-01-01T00:00:00.000Z</LastModified><ETag>&quot;0123456789abcdef0123456789abcdef&quot;</ETag><Size>1</Size><StorageClass>STANDARD</StorageClass></Version></ListVersionsResult>"#
+    )
+}
+
+fn delete_result_page(deleted: &[(String, Option<String>)]) -> String {
+    let mut entries = String::new();
+    for (key, version_id) in deleted {
+        let version_id_tag = version_id
+            .as_ref()
+            .map(|v| format!("<VersionId>{v}</VersionId>"))
+            .unwrap_or_default();
+        entries.push_str(&format!(
+            "<Deleted><Key>{key}</Key>{version_id_tag}</Deleted>"
+        ));
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">{entries}</DeleteResult>"#
+    )
+}
+
+/// Spawn the s3rm binary pointed at the fake endpoint with static
+/// credentials, so no AWS configuration on the host is consulted.
+fn spawn_s3rm(endpoint: &str, extra_args: &[&str]) -> Child {
+    let mut args = vec![
+        "--target-endpoint-url",
+        endpoint,
+        "--target-force-path-style",
+        "--target-access-key",
+        "fake-access-key",
+        "--target-secret-access-key",
+        "fake-secret-key",
+        "--target-region",
+        "us-east-1",
+        "--aws-config-file",
+        "./test_data/test_config/config",
+        "--aws-shared-credentials-file",
+        "./test_data/test_config/credentials",
+    ];
+    args.extend_from_slice(extra_args);
+    args.push("s3://fake-sigint-bucket/");
+
+    Command::new(env!("CARGO_BIN_EXE_s3rm"))
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn s3rm")
+}
+
+/// Wait until the fake endpoint has served at least `at_least` requests
+/// counted by `counter`, so the child is provably inside the pipeline (its
+/// Ctrl+C handler is installed before the pipeline starts, thus long since
+/// registered). Fails fast with the child's stderr if it exits early.
+fn wait_for_count(child: &mut Child, counter: &AtomicUsize, at_least: usize, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while counter.load(Ordering::SeqCst) < at_least {
+        if let Some(status) = child.try_wait().expect("failed to poll s3rm") {
+            let stderr = read_stderr(child);
+            panic!(
+                "s3rm exited ({status:?}) before the fake S3 served {at_least} {what}\nstderr: {stderr}"
+            );
+        }
+        assert!(
+            Instant::now() < deadline,
+            "fake S3 served only {} {what} before timeout",
+            counter.load(Ordering::SeqCst)
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Wait for the child to exit within `deadline` — SIGINT must terminate
+/// the process promptly, not hang it. Kills the child on timeout.
+fn wait_with_deadline(child: &mut Child, deadline: Duration) -> std::process::ExitStatus {
+    let end = Instant::now() + deadline;
+    loop {
+        if let Some(status) = child.try_wait().expect("failed to poll s3rm") {
+            return status;
+        }
+        if Instant::now() >= end {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("s3rm did not exit within {deadline:?}");
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+/// Read the child's stderr after it has exited.
+fn read_stderr(child: &mut Child) -> String {
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = pipe.read_to_string(&mut stderr);
+    }
+    stderr
+}
+
+#[cfg(target_family = "unix")]
+fn send_sigint(child: &Child) {
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(child.id() as i32),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .expect("failed to send SIGINT to s3rm");
+}
+
+/// Shared body of the SIGINT tests: start an endless deletion, wait until
+/// the child is provably mid-pipeline (`min_pages` list pages and
+/// `min_deletes` delete requests served), interrupt it, and require a
+/// graceful exit with code 130 — `code()` is `None` for a raw signal kill,
+/// so this also proves the signal was caught rather than terminating the
+/// process directly — and a quiet stderr. Returns the fake endpoint for
+/// extra assertions.
+#[cfg(target_family = "unix")]
+fn assert_sigint_exits_130(
+    kind: ListingKind,
+    extra_args: &[&str],
+    min_pages: usize,
+    min_deletes: usize,
+    label: &str,
+) -> FakeS3 {
+    let fake = spawn_fake_s3(kind, None);
+    let mut child = spawn_s3rm(&fake.endpoint, extra_args);
+
+    wait_for_count(&mut child, &fake.pages_served, min_pages, "list page(s)");
+    if min_deletes > 0 {
+        wait_for_count(
+            &mut child,
+            &fake.deletes_served,
+            min_deletes,
+            "delete request(s)",
+        );
+    }
+    send_sigint(&child);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(15));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "[{label}] expected graceful exit 130 after SIGINT, got {status:?}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked") && !stderr.contains("s3rm failed"),
+        "[{label}] SIGINT should terminate quietly\nstderr: {stderr}"
+    );
+
+    fake
+}
+
+/// Ctrl+C during a `--dry-run` listing: only list requests are ever in
+/// flight, and none may turn into deletions during shutdown.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_dry_run_listing_exits_130() {
+    let fake = assert_sigint_exits_130(
+        ListingKind::Objects,
+        &["--dry-run", "--max-parallel-listings", "1"],
+        3,
+        0,
+        "dry-run",
+    );
+    assert_eq!(
+        fake.deletes_served.load(Ordering::SeqCst),
+        0,
+        "a dry run must never send delete requests"
+    );
+}
+
+/// Ctrl+C with the default configuration (`--force` alone): parallel
+/// listing dispatch and batch-deletion buffering, exactly as a plain
+/// `s3rm -f s3://bucket/` runs.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_default_parallel_listing_exits_130() {
+    assert_sigint_exits_130(ListingKind::Objects, &["--force"], 3, 0, "default-parallel");
+}
+
+/// Ctrl+C while batch `DeleteObjects` requests are actively being sent
+/// (`--batch-size 2` flushes a batch every two listed objects).
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_batch_deletion_exits_130() {
+    assert_sigint_exits_130(
+        ListingKind::Objects,
+        &[
+            "--force",
+            "--batch-size",
+            "2",
+            "--max-parallel-listings",
+            "1",
+        ],
+        3,
+        1,
+        "batch-deletion",
+    );
+}
+
+/// Ctrl+C while single-object `DeleteObject` requests (`--batch-size 1`)
+/// are actively being sent.
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_single_object_deletion_exits_130() {
+    assert_sigint_exits_130(
+        ListingKind::Objects,
+        &[
+            "--force",
+            "--batch-size",
+            "1",
+            "--max-parallel-listings",
+            "1",
+        ],
+        3,
+        2,
+        "single-deletion",
+    );
+}
+
+/// Ctrl+C during `--delete-all-versions` (versioning prerequisite check,
+/// `ListObjectVersions` paging, and versioned batch deletion).
+#[test]
+#[cfg(target_family = "unix")]
+fn sigint_during_versions_deletion_exits_130() {
+    assert_sigint_exits_130(
+        ListingKind::Versions,
+        &[
+            "--force",
+            "--delete-all-versions",
+            "--batch-size",
+            "2",
+            "--max-parallel-listings",
+            "1",
+        ],
+        3,
+        1,
+        "versions",
+    );
+}
+
+/// Control: the same harness without SIGINT completes the full
+/// list-and-delete run and exits 0 — the SIGINT handling must not affect
+/// uninterrupted runs.
+#[test]
+fn deletion_without_sigint_exits_zero() {
+    let fake = spawn_fake_s3(ListingKind::Objects, Some(3));
+    let mut child = spawn_s3rm(&fake.endpoint, &["--force", "--max-parallel-listings", "1"]);
+
+    let status = wait_with_deadline(&mut child, Duration::from_secs(30));
+    let stderr = read_stderr(&mut child);
+
+    assert_eq!(
+        status.code(),
+        Some(0),
+        "expected exit 0, got {status:?}\nstderr: {stderr}"
+    );
+    assert_eq!(fake.pages_served.load(Ordering::SeqCst), 3);
+    assert!(
+        fake.deletes_served.load(Ordering::SeqCst) >= 1,
+        "the run must have sent at least one delete request"
+    );
+    let deleted = fake.deleted_keys.lock().unwrap();
+    for key in ["page-0.txt", "page-1.txt", "page-2.txt"] {
+        assert!(
+            deleted.iter().any(|deleted_key| deleted_key == key),
+            "delete requests missing {key}; deleted: {deleted:?}"
+        );
+    }
+}


### PR DESCRIPTION
[Breaking change] A deletion interrupted by Ctrl+C (SIGINT) now exits with code 130 (128 + SIGINT, the conventional shell encoding for termination by signal) instead of 0. Previously an interrupted deletion was indistinguishable from a successful one by its exit code; scripts that test the exit status should treat 130 as user interruption rather than success.

The Ctrl+C handler records the signal in a process-global flag before cancelling the pipeline, and main checks it once the pipeline has stopped — Ctrl+C takes precedence over whatever the forced shutdown recorded. No other logic is modified: output, error paths, and the confirmation-prompt behavior (where the default OS handler still terminates the process directly) are unchanged, and uninterrupted runs still exit 0. Same fix as nidor1998/s3ls-rs#34.

Adds process-level regression tests (tests/cli_sigint_exit_code.rs) that run the binary against a minimal in-process S3 endpoint (no AWS access needed), interrupt it mid-listing and mid-deletion (dry-run, default parallel listing, batch, single-object, and versioned deletion), and require a graceful exit 130 — `code()` is `None` for a raw signal kill, so this also proves the signal was caught — plus a no-SIGINT control that must still complete the full list-and-delete run and exit 0.

**Contributing**

- Bug reports are welcome, but responses are not guaranteed.
- Since this project is considered functionally complete, I will not accept any feature requests.
- If you find this project useful, feel free to fork and modify it as you wish.

🔒 I consider this project “complete” and will maintain it only minimally going forward.
However, I intend to keep the AWS SDK for Rust and other dependencies up to date monthly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Interrupted deletion operations now exit with status code 130 when stopped with Ctrl+C.
  * User interruptions are clearly distinguished from successful completion and other outcomes.
  * Dry runs, parallel operations, batch deletions, single-object deletions, and version deletions consistently report the correct interruption status.

* **Documentation**
  * Added release notes and usage documentation for the updated Ctrl+C behavior in version 1.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->