### PR TITLE
update/v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-08-08
+
+### Fixed
+
+- Command line validation error messages (e.g. `error: --rate-limit-objects (100) must be greater than or equal to
+  --batch-size (500).`) now end with a newline. Previously the message was printed without a trailing newline, so the
+  next shell prompt appeared on the same line.
+
 ## [1.6.0] - 2026-08-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2664,7 +2664,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3rm-rs"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3rm-rs"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2024"
 authors = ["nidor1998 <nidor1998@gmail.com>"]
 description = "Fast Amazon S3 object deletion tool."

--- a/src/bin/s3rm/main.rs
+++ b/src/bin/s3rm/main.rs
@@ -52,7 +52,13 @@ fn load_config_exit_if_err() -> Config {
     match Config::try_from(CLIArgs::parse()) {
         Ok(config) => config,
         Err(error_message) => {
-            clap::Error::raw(clap::error::ErrorKind::ValueValidation, error_message).exit();
+            // clap prints raw error messages verbatim, so terminate the line
+            // ourselves to keep the shell prompt off the message line.
+            clap::Error::raw(
+                clap::error::ErrorKind::ValueValidation,
+                format!("{error_message}\n"),
+            )
+            .exit();
         }
     }
 }


### PR DESCRIPTION
## [1.6.1] - 2026-08-08

### Fixed

- Command line validation error messages (e.g. `error: --rate-limit-objects (100) must be greater than or equal to --batch-size (500).`) now end with a newline. Previously the message was printed without a trailing newline, so the next shell prompt appeared on the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Command-line validation errors now end with a newline, keeping the next shell prompt on a separate line.

- **Release**
  - Updated the package to version 1.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->